### PR TITLE
feat: logSensitive, capture warnings

### DIFF
--- a/messages/messages.md
+++ b/messages/messages.md
@@ -1,0 +1,3 @@
+# warning.security
+
+This command will expose sensitive information that allows for subsequent activity using your current authenticated session. Sharing this information is equivalent to logging someone in under the current credential, resulting in unintended access and escalation of privilege. For additional information, please review the authorization section of the https://developer.salesforce.com/docs/atlas.en-us.234.0.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_web_flow.htm

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@oclif/core": "^0.5.39",
+    "@oclif/core": "^0.5.41",
     "@salesforce/core": "^3.6.2",
     "@salesforce/kit": "^1.5.17",
     "@salesforce/ts-types": "^1.5.20",

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -30,7 +30,6 @@ export abstract class SfCommand<T> extends Command {
   public static configurationVariablesSection?: HelpSection;
   public static envVariablesSection?: HelpSection;
   public static errorCodes?: HelpSection;
-  public static exposesSensitiveInfo?: boolean;
 
   private warnings: SfCommand.Warning[] = [];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,10 +430,10 @@
     is-wsl "^2.1.1"
     tslib "^2.0.0"
 
-"@oclif/core@^0.5.39":
-  version "0.5.39"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-0.5.39.tgz#d00705f31c5e6617145e84bb9dd50156cf3b01c5"
-  integrity sha512-4XusxLX8PnHDQxtRP25PImlkIj1Mlx6wt0NWb1FxQGvTJOAgXGJZl3YB02ZeXZLYbeKA2A3AqqxFTTKbADnZng==
+"@oclif/core@^0.5.41":
+  version "0.5.41"
+  resolved "https://registry.npmjs.org/@oclif/core/-/core-0.5.41.tgz#54ab600b1b6017f3849e629401eafd4f4e3a5c2e"
+  integrity sha512-zEYbpxSQr80t7MkLMHOmZr8QCrCIbVrI7fLSZWlsvD2AEM0vvzuhWymjo9/kHy2/kNfxwu7NTI4i2a0zoHu11w==
   dependencies:
     "@oclif/linewrap" "^1.0.0"
     chalk "^4.1.0"


### PR DESCRIPTION
- Adds `logSensitive` to `SfCommand` so that commands can log a warning to the user before logging sensitive information (e.g. access tokens)
- Capture warnings in `SfCommand` so that we can put them in json output

[skip-validate-pr]