### PR TITLE
feat: add spinner methods

### DIFF
--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2020, salesforce.com, inc.
+ * Copyright (c) 2021, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Command, HelpSection, Interfaces } from '@oclif/core';
+import { Command, Config, HelpSection, Interfaces } from '@oclif/core';
 import { Messages } from '@salesforce/core';
+import { Spinner } from './ux';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
@@ -31,7 +32,14 @@ export abstract class SfCommand<T> extends Command {
   public static envVariablesSection?: HelpSection;
   public static errorCodes?: HelpSection;
 
+  public spinner: Spinner;
+
   private warnings: SfCommand.Warning[] = [];
+
+  public constructor(argv: string[], config: Config) {
+    super(argv, config);
+    this.spinner = new Spinner(this.jsonEnabled());
+  }
 
   /**
    * Log warning to users. If --json is enabled, then the warning

--- a/src/ux.ts
+++ b/src/ux.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { cli } from 'cli-ux';
+
+/**
+ * This class is a light wrapper around cli.action that allows us to
+ * automatically suppress any actions if `--json` flag is present.
+ */
+export class Spinner {
+  public constructor(private jsonEnabled: boolean) {}
+
+  /**
+   * Start a spinner on the console.
+   */
+  public start(action: string, status?: string, opts?: { stdout?: boolean }): void {
+    if (!this.jsonEnabled) cli.action.start(action, status, opts);
+  }
+
+  /**
+   * Stop a spinner on the console.
+   */
+  public stop(msg?: string): void {
+    if (!this.jsonEnabled) cli.action.stop(msg);
+  }
+
+  /**
+   * Pause a spinner on the console.
+   */
+  public pause(fn: () => unknown, icon?: string): void {
+    if (!this.jsonEnabled) cli.action.pause(fn, icon);
+  }
+}

--- a/src/ux.ts
+++ b/src/ux.ts
@@ -22,14 +22,21 @@ export class Spinner {
   }
 
   /**
-   * Stop a spinner on the console.
+   * Stop the spinner on the console.
    */
   public stop(msg?: string): void {
     if (!this.jsonEnabled) cli.action.stop(msg);
   }
 
   /**
-   * Pause a spinner on the console.
+   * Set the status of the current spinner.
+   */
+  public status(status: string): void {
+    if (!this.jsonEnabled) cli.action.status = status;
+  }
+
+  /**
+   * Pause the spinner on the console.
    */
   public pause(fn: () => unknown, icon?: string): void {
     if (!this.jsonEnabled) cli.action.pause(fn, icon);

--- a/src/ux.ts
+++ b/src/ux.ts
@@ -31,8 +31,15 @@ export class Spinner {
   /**
    * Set the status of the current spinner.
    */
-  public status(status: string): void {
+  public set status(status: string | undefined) {
     if (!this.jsonEnabled) cli.action.status = status;
+  }
+
+  /**
+   * Get the status of the current spinner.
+   */
+  public get status(): string | undefined {
+    return cli.action.status;
   }
 
   /**


### PR DESCRIPTION
Expose spinner related methods in `SfCommand`

#### Usage

```typescript
import { SfCommand } from '@salesforce/sf-plugins-core';
import { sleep } from '@salesforce/kit';

export default class MyCommand extends SfCommand {
  public async run(): Promise<void> {
    this.spinner.start('Doing some stuff');
    await sleep(5000);
    this.spinner.stop('Success');
  }
}
```

@W-10330464@