### PR TITLE
feat: add requiresProject property

### DIFF
--- a/messages/messages.md
+++ b/messages/messages.md
@@ -1,3 +1,7 @@
 # warning.security
 
 This command will expose sensitive information that allows for subsequent activity using your current authenticated session. Sharing this information is equivalent to logging someone in under the current credential, resulting in unintended access and escalation of privilege. For additional information, please review the authorization section of the https://developer.salesforce.com/docs/atlas.en-us.234.0.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_web_flow.htm
+
+# errors.RequiresProject
+
+This command is required to run from within a Salesforce project directory.


### PR DESCRIPTION
Add a `requiresProject` property, allowing commands to throw an error if it's not run inside a Salesforce project directory

@W-10024521@