### PR TITLE
Sm/flags

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,6 +1,7 @@
 {
   "require": "test/init.js, ts-node/register, source-map-support/register",
-  "watch-extensions": "ts",
+  "watch-extensions": ["ts", "md"],
+  "watch-files": ["src", "test", "messages"],
   "recursive": true,
   "reporter": "spec",
   "timeout": 5000

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Description
 
-The @salesforce/sf-pluins-core provides utilities for writing [sf](https://github.com/salesforcecli/cli) plugins.
+The @salesforce/sf-plugins-core provides utilities for writing [sf](https://github.com/salesforcecli/cli) plugins.
 
 ## SfCommand Abstract Class
 
@@ -43,3 +43,46 @@ A general purpose class that prompts a user for information. See [inquirer NPM M
 ## Flags
 
 Flags is a convenience reference to [@oclif/core#Flags](https://github.com/oclif/core/blob/main/src/flags.ts)
+
+### Specialty Flags
+
+These flags can be imported into a command and used like any other flag. See code examples in the links
+
+- [apiVersion](src/flags/apiVersion.ts)
+  - specifies a Salesforce API version.
+  - reads from Config (if available)
+  - validates version is still active
+  - warns if version if deprecated
+- [dirExsts](src/flags/fsFlags.ts)
+  - validates that directory specified exists and is a directory
+- [fileExsts](src/flags/fsFlags.ts)
+  - validates that file specified exists and is a file
+- [requiredOrgFlag](src/flags/orgFlags.ts)
+  - accepts a username or alias
+  - aware of configuration defaults
+  - throws if org or default doesn't exist or can't be found
+    [optionalOrgFlag](src/flags/orgFlags.ts)
+  - accepts a username or alias
+  - aware of configuration defaults
+  - might be undefined if an org isn't found
+- [requiredHubFlag](src/flags/orgFlags.ts)
+  - accepts a username or alias
+  - aware of configuration defaults
+  - throws if org or default doesn't exist or can't be found
+  - throws if an org is found but is not a dev hub
+
+### Flag Builders
+
+These functions accept parameters and return a flag with configured behavior. See code examples in the link
+
+- [buildDurationFlag](src/flags/duration.ts)
+
+  - specify a unit
+  - optionally specify a min, max, and defaultValue
+  - returns a [Duration](https://github.com/forcedotcom/kit/blob/main/src/duration.ts)
+  - can be undefined if you don't set the default
+
+- [buildIdFlag](src/flags/salesforceId.ts)
+  - validates that IDs are valid salesforce ID
+  - optionally restrict to 15/18 char
+  - optionally require it to be begin with a certain prefix

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ These flags can be imported into a command and used like any other flag. See cod
   - accepts a username or alias
   - aware of configuration defaults
   - throws if org or default doesn't exist or can't be found
-    [optionalOrgFlag](src/flags/orgFlags.ts)
+- [optionalOrgFlag](src/flags/orgFlags.ts)
   - accepts a username or alias
   - aware of configuration defaults
   - might be undefined if an org isn't found

--- a/messages/messages.md
+++ b/messages/messages.md
@@ -1,7 +1,67 @@
 # warning.security
 
-This command will expose sensitive information that allows for subsequent activity using your current authenticated session. Sharing this information is equivalent to logging someone in under the current credential, resulting in unintended access and escalation of privilege. For additional information, please review the authorization section of the https://developer.salesforce.com/docs/atlas.en-us.234.0.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_web_flow.htm
+This command will expose sensitive information that allows for subsequent activity using your current authenticated session. Sharing this information is equivalent to logging someone in under the current credential, resulting in unintended access and escalation of privilege. For additional information, please review the authorization section of the <https://developer.salesforce.com/docs/atlas.en-us.234.0.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_web_flow.htm>
 
 # errors.RequiresProject
 
 This command is required to run from within a Salesforce project directory.
+
+# errors.InvalidIdLength
+
+The id must be %s characters.
+
+# errors.InvalidId
+
+The id is invalid.
+
+# errors.InvalidPrefix
+
+The id must begin with %s.
+
+# errors.NoDefaultEnv
+
+No default environment found. Use -e or --target-org to specify an environment.
+
+# errors.NoDefaultDevHub
+
+No default dev hub found. Use -v or --target-dev-hub to specify an environment.
+
+# errors.NotADevHub
+
+The specified org %s is not a Dev Hub.
+
+# flags.apiVersion.description
+
+Override the api version used for api requests made by this command
+
+# flags.apiVersion.overrideWarning
+
+apiVersion configuration overridden at %s
+
+# flags.apiVersion.warning.deprecated
+
+API versions up to %s are deprecated. See %s for more information.
+
+# flags.apiVersion.errors.InvalidApiVersion
+
+%s is not a valid API version.
+
+# flags.apiVersion.errors.RetiredApiVersion
+
+The API version must be greater than %s.
+
+# flags.existingDirectory.errors.MissingDirectory
+
+No directory found: %s.
+
+# flags.existingDirectory.errors.NotADirectory
+
+No directory found: %s.
+
+# flags.existingFile.errors.MissingFile
+
+No file found: %s.
+
+# flags.existingFile.errors.NotAFile
+
+No file found: %s.

--- a/messages/messages.md
+++ b/messages/messages.md
@@ -65,3 +65,11 @@ No file found: %s.
 # flags.existingFile.errors.NotAFile
 
 No file found: %s.
+
+# flags.duration.errors.InvalidInput
+
+The value must be an integer.
+
+# flags.duration.errors.DurationBounds
+
+The value must be between %s and %s (inclusive).

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "/messages"
   ],
   "dependencies": {
-    "@oclif/core": "^1.2.0",
+    "@oclif/core": "^1.3.6",
     "@salesforce/core": "3.7.3",
     "@salesforce/kit": "^1.5.17",
     "@salesforce/ts-types": "^1.5.20",

--- a/src/exported.ts
+++ b/src/exported.ts
@@ -13,3 +13,9 @@ export { SfHook } from './hooks';
 export * from './types';
 export { SfCommand, SfCommandInterface } from './sfCommand';
 export { Flags } from '@oclif/core';
+
+// custom flags
+export { requiredOrgFlag, requiredHubFlag } from './flags/orgFlags';
+export { buildIdFlag } from './flags/salesforceId';
+export { apiVersionFlag } from './flags/apiVersion';
+export { existingDirectory, existingFile } from './flags/fsFlags';

--- a/src/exported.ts
+++ b/src/exported.ts
@@ -19,3 +19,4 @@ export { requiredOrgFlag, requiredHubFlag } from './flags/orgFlags';
 export { buildIdFlag } from './flags/salesforceId';
 export { apiVersionFlag } from './flags/apiVersion';
 export { existingDirectory, existingFile } from './flags/fsFlags';
+export { buildDurationFlag, DurationFlagConfig } from './flags/duration';

--- a/src/flags/apiVersion.ts
+++ b/src/flags/apiVersion.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { Flags, CliUx } from '@oclif/core';
+import { Messages, sfdc } from '@salesforce/core';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
+
+// versions below this are retired
+export const minValidApiVersion = 21;
+// this and all un-retired versions below it are deprecated
+export const maxDeprecated = 30;
+export const maxDeprecatedUrl = 'https://help.salesforce.com/s/articleView?id=000354473&type=1;';
+
+/**
+ * apiVersion for a salesforce org's rest api.
+ * Will validate format and that the api version is still supported.
+ * Will default to the version specified in Config, if it exists (and will provide an override warning)
+ *
+ * CAVEAT: unlike the apiversion flag on sfdxCommand, this does not set the version on the org/connection
+ * We leave this up to the plugins to implement
+ */
+export const apiVersionFlag = Flags.build<string>({
+  parse: async (input: string) => validate(input),
+  default: async () => await getDefaultFromConfig(),
+  description: messages.getMessage('flags.apiVersion.description'),
+});
+
+const getDefaultFromConfig = async (): Promise<string | undefined> => {
+  // (perf) only import ConfigAggregator and cliUX if necessary
+  const { ConfigAggregator } = await import('@salesforce/core');
+  const config = await ConfigAggregator.create();
+  const apiVersionFromConfig = config.getInfo('apiVersion')?.value as string;
+  if (apiVersionFromConfig) {
+    CliUx.ux.warn(messages.getMessage('flags.apiVersion.overrideWarning', [apiVersionFromConfig]));
+    return validate(apiVersionFromConfig);
+  }
+};
+
+const validate = async (input: string): Promise<string> => {
+  // basic format check
+  if (!sfdc.validateApiVersion(input)) {
+    throw messages.createError('flags.apiVersion.errors.InvalidApiVersion', [input]);
+  }
+  const requestedVersion = parseInt(input, 10);
+  if (requestedVersion < minValidApiVersion) {
+    throw messages.createError('flags.apiVersion.errors.RetiredApiVersion', [minValidApiVersion]);
+  }
+  if (requestedVersion <= maxDeprecated) {
+    CliUx.ux.warn(messages.getMessage('flags.apiVersion.warning.deprecated', [maxDeprecated, maxDeprecatedUrl]));
+  }
+
+  return input;
+};

--- a/src/flags/duration.ts
+++ b/src/flags/duration.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { Flags } from '@oclif/core';
+import { Definition } from '@oclif/core/lib/interfaces';
+import { Messages } from '@salesforce/core';
+import { Duration } from '@salesforce/kit';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
+
+type DurationUnit = Lowercase<keyof typeof Duration.Unit>;
+
+export interface DurationFlagConfig {
+  unit: Required<DurationUnit>;
+  defaultValue?: number;
+  min?: number;
+  max?: number;
+}
+
+/**
+ * Duration flag with built-in default and min/max validation
+ * You must specify a unit
+ * Defaults to undefined if you don't specify a default
+ *
+ * @example
+ * import { SfCommand, buildDurationFlag } from '@salesforce/sf-plugins-core';
+ * public static flags = {
+ *    'wait': buildDurationFlag({ min: 1, unit: , defaultValue: 33 })({
+ *       char: 'w',
+ *       description: 'Wait time in minutes'
+ *    }),
+ * }
+ */
+export const buildDurationFlag = (durationConfig: DurationFlagConfig): Definition<Duration> => {
+  return Flags.build<Duration>({
+    parse: async (input: string) => validate(input, durationConfig),
+    default: durationConfig.defaultValue
+      ? async () => toDuration(durationConfig.defaultValue as number, durationConfig.unit)
+      : undefined,
+  });
+};
+
+const validate = (input: string, config: DurationFlagConfig): Duration => {
+  const { min, max, unit } = config || {};
+  let parsedInput: number;
+
+  try {
+    parsedInput = parseInt(input, 10);
+    if (typeof parsedInput !== 'number' || isNaN(parsedInput)) {
+      throw messages.createError('flags.duration.errors.InvalidInput');
+    }
+  } catch (e) {
+    throw messages.createError('flags.duration.errors.InvalidInput');
+  }
+
+  if (min && parsedInput < min) {
+    throw messages.createError('flags.duration.errors.DurationBounds', [min, max]);
+  }
+  if (max && parsedInput > max) {
+    throw messages.createError('flags.duration.errors.DurationBounds', [min, max]);
+  }
+  return toDuration(parsedInput, unit);
+};
+
+const toDuration = (parsedInput: number, unit: DurationUnit): Duration => {
+  return Duration[unit](parsedInput);
+};

--- a/src/flags/fsFlags.ts
+++ b/src/flags/fsFlags.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as fs from 'fs';
+import { Flags } from '@oclif/core';
+import { Messages } from '@salesforce/core';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
+
+/**
+ * Accepts a directory path.  Validates that the directory exists and is a directory.
+ */
+export const existingDirectory = Flags.build<string>({
+  parse: async (input: string) => await dirExists(input),
+});
+
+/**
+ * Accepts a file path.  Validates that the file exists and is a file.
+ */
+export const existingFile = Flags.build<string>({
+  parse: async (input: string) => await fileExists(input),
+});
+
+const dirExists = async (input: string): Promise<string> => {
+  if (!fs.existsSync(input)) {
+    throw messages.createError('flags.existingDirectory.errors.MissingDirectory', [input]);
+  }
+  if (!(await fs.promises.stat(input)).isDirectory()) {
+    throw messages.createError('flags.existingDirectory.errors.NotADirectory', [input]);
+  }
+
+  return input;
+};
+
+const fileExists = async (input: string): Promise<string> => {
+  if (!fs.existsSync(input)) {
+    throw messages.createError('flags.existingFile.errors.MissingFile', [input]);
+  }
+  if (!(await fs.promises.stat(input)).isFile()) {
+    throw messages.createError('flags.existingFile.errors.NotAFile', [input]);
+  }
+
+  return input;
+};

--- a/src/flags/orgFlags.ts
+++ b/src/flags/orgFlags.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { Flags } from '@oclif/core';
+import { Messages, Org, ConfigAggregator } from '@salesforce/core';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
+
+const maybeGetOrg = async (input?: string): Promise<Org | undefined> => Org.create({ aliasOrUsername: input });
+const getOrgOrThrow = async (input?: string): Promise<Org> => {
+  const org = await maybeGetOrg(input);
+  if (!org) {
+    throw messages.createError('errors.NoDefaultEnv');
+  }
+  return org;
+};
+
+const getHubOrThrow = async (aliasOrUsername?: string): Promise<Org> => {
+  if (!aliasOrUsername) {
+    // check config for a default
+    const config = await ConfigAggregator.create();
+    aliasOrUsername = config.getInfo('defaultdevhubusername')?.value as string;
+    if (!aliasOrUsername) {
+      throw messages.createError('errors.NoDefaultHub', [aliasOrUsername]);
+    }
+  }
+  const org = await Org.create({ aliasOrUsername });
+  // check the synchronous, cached version and only use "determine" if we didn't get a positive result
+  if (!org.isDevHubOrg() || !(await org.determineIfDevHubOrg())) {
+    throw messages.createError('errors.NotADevHub', [aliasOrUsername]);
+  }
+  return org;
+};
+
+/**
+ * An optional org specified by username or alias
+ * Will default to the default org if one is not specified.
+ * Will not throw if the specified org and default do not exist
+ *
+ * @example
+ * import { SfCommand, optionalOrgFlag } from '@salesforce/sf-plugins-core';
+ * public static flags = {
+ *     // setting length or prefix
+ *    'target-org': optionalOrgFlag(),
+ *    // adding properties
+ *    'flag2': optionalOrgFlag()({
+ *        required: true,
+ *        description: 'flag2 description',
+ *     }),
+ * }
+ */
+export const optionalOrgFlag = Flags.build<Org | undefined>({
+  char: 'e',
+  parse: async (input: string | undefined) => await maybeGetOrg(input),
+  default: async () => await maybeGetOrg(undefined),
+});
+
+/**
+ * An required org, specified by username or alias
+ * Will throw if the specified org default do not exist
+ * Will default to the default org if one is not specified.
+ * Will throw if no default org exists and none is specified
+ *
+ * @example
+ * import { SfCommand, requiredOrgFlag } from '@salesforce/sf-plugins-core';
+ * public static flags = {
+ *     // setting length or prefix
+ *    'target-org': requiredOrgFlag(),
+ *    // adding properties
+ *    'flag2': requiredOrgFlag()({
+ *        required: true,
+ *        description: 'flag2 description',
+ *        char: 'o'
+ *     }),
+ * }
+ */
+export const requiredOrgFlag = Flags.build<Org>({
+  char: 'e',
+  parse: async (input: string | undefined) => await getOrgOrThrow(input),
+  default: async () => await getOrgOrThrow(undefined),
+});
+
+/**
+ * An required org that is a devHub
+ * Will throw if the specified org does not exist
+ * Will default to the default dev hub if one is not specified
+ * Will throw if no default deb hub exists and none is specified
+ *
+ * @example
+ * import { SfCommand, requiredOrgFlag } from '@salesforce/sf-plugins-core';
+ * public static flags = {
+ *     // setting length or prefix
+ *    'target-org': requiredHubFlag(),
+ *    // adding properties
+ *    'flag2': requiredHubFlag()({
+ *        required: true,
+ *        description: 'flag2 description',
+ *        char: 'h'
+ *     }),
+ * }
+ */
+export const requiredHubFlag = Flags.build<Org>({
+  char: 'v',
+  parse: async (input: string | undefined) => await getHubOrThrow(input),
+  default: async () => await getHubOrThrow(undefined),
+});

--- a/src/flags/salesforceId.ts
+++ b/src/flags/salesforceId.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { Flags } from '@oclif/core';
+import { Definition } from '@oclif/core/lib/interfaces';
+import { Messages, sfdc } from '@salesforce/core';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
+
+interface IdFlagConfig {
+  /**
+   * Can specify if the version must be 15 or 18 characters long.  Leave blank to allow either 15 or 18.
+   */
+  length?: 15 | 18;
+  /**
+   * If the ID belongs to a certain sobject type, specify the 3 character prefix.
+   */
+  startsWith?: string;
+}
+
+/**
+ * Id flag with built-in validation.  Short character is `i`
+ *
+ * @example
+ * import { SfCommand, buildIdFlag } from '@salesforce/sf-plugins-core';
+ * public static flags = {
+ *     // set length or prefix
+ *    'flag-name': buildIdFlag({ length: 15, startsWith: '00D' })(),
+ *    // add flag properties
+ *    'flag2': buildIdFlag()({
+ *        required: true,
+ *        description: 'flag2 description',
+ *     }),
+ *    // override the character i
+ *    'flag3': buildIdFlag()({
+ *        char: 'j',
+ *     }),
+ * }
+ */
+export const buildIdFlag = ({ length, startsWith }: IdFlagConfig): Definition<string> => {
+  return Flags.build<string>({
+    char: 'i',
+    parse: async (input: string) => validate(input, { length, startsWith }),
+  });
+};
+
+const validate = (input: string, config?: IdFlagConfig): string => {
+  const { length, startsWith } = config || {};
+  if (length && input.length !== length) {
+    throw messages.createError('errors.InvalidIdLength', [length]);
+  }
+  if (!length && ![15, 18].includes(input.length)) {
+    throw messages.createError('errors.InvalidIdLength', ['15 or 18']);
+  }
+  if (!sfdc.validateSalesforceId(input)) {
+    throw messages.createError('errors.InvalidId');
+  }
+  if (startsWith && !input.startsWith(startsWith)) {
+    throw messages.createError('errors.InvalidPrefix', [startsWith]);
+  }
+  return input;
+};

--- a/test/unit/flags/apiVersion.test.ts
+++ b/test/unit/flags/apiVersion.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from 'chai';
+import { CliUx, Parser } from '@oclif/core';
+import { Messages } from '@salesforce/core';
+import * as sinon from 'sinon';
+import { apiVersionFlag, minValidApiVersion, maxDeprecated, maxDeprecatedUrl } from '../../../src/flags/apiVersion';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
+
+describe('fs flags', () => {
+  const sandbox = sinon.createSandbox();
+  let uxStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    uxStub = sandbox.stub(CliUx.ux, 'warn');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('passes with a valid apiVersion', async () => {
+    const versionToTest = `${maxDeprecated + 10}.0`;
+    const out = await Parser.parse([`--api-version=${versionToTest}`], {
+      flags: { 'api-version': apiVersionFlag() },
+    });
+    expect(out.flags).to.deep.include({ 'api-version': versionToTest });
+    // no deprecation warning
+    expect(uxStub.callCount).to.equal(0);
+  });
+
+  it('passes with minimum valid apiVersion', async () => {
+    const versionToTest = `${maxDeprecated + 1}.0`;
+    const out = await Parser.parse([`--api-version=${versionToTest}`], {
+      flags: { 'api-version': apiVersionFlag() },
+    });
+    expect(out.flags).to.deep.include({ 'api-version': versionToTest });
+    // no deprecation warning
+    expect(uxStub.callCount).to.equal(0);
+  });
+
+  it('throws on invalid version', async () => {
+    try {
+      const out = await Parser.parse(['--api-version=foo'], {
+        flags: { 'api-version': apiVersionFlag() },
+      });
+      throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).to.equal(messages.getMessage('flags.apiVersion.errors.InvalidApiVersion', ['foo']));
+    }
+  });
+
+  it('throws on retired version', async () => {
+    const versionToTest = `${minValidApiVersion - 1}.0`;
+
+    try {
+      const out = await Parser.parse([`--api-version=${versionToTest}`], {
+        flags: { 'api-version': apiVersionFlag() },
+      });
+      throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).to.equal(
+        messages.getMessage('flags.apiVersion.errors.RetiredApiVersion', [minValidApiVersion])
+      );
+    }
+  });
+
+  it('warns on highest deprecated version', async () => {
+    const versionToTest = `${maxDeprecated}.0`;
+    const out = await Parser.parse([`--api-version=${versionToTest}`], {
+      flags: { 'api-version': apiVersionFlag() },
+    });
+    expect(out.flags).to.deep.include({ 'api-version': versionToTest });
+    expect(uxStub.callCount).to.equal(1);
+    expect(uxStub.firstCall.args[0]).to.include(maxDeprecatedUrl);
+  });
+
+  it('warns on lowest deprecated version', async () => {
+    const versionToTest = `${minValidApiVersion}.0`;
+    const out = await Parser.parse([`--api-version=${versionToTest}`], {
+      flags: { 'api-version': apiVersionFlag() },
+    });
+    expect(out.flags).to.deep.include({ 'api-version': versionToTest });
+    expect(uxStub.callCount).to.equal(1);
+    expect(uxStub.firstCall.args[0]).to.include(maxDeprecatedUrl);
+  });
+});

--- a/test/unit/flags/duration.test.ts
+++ b/test/unit/flags/duration.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Parser } from '@oclif/core';
+import { Messages } from '@salesforce/core';
+import { expect } from 'chai';
+import { Duration } from '@salesforce/kit';
+import { buildDurationFlag } from '../../../src/flags/duration';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
+
+describe('duration flag', () => {
+  describe('no default, hours', () => {
+    const buildProps = {
+      flags: {
+        wait: buildDurationFlag({
+          unit: 'hours',
+        })({ description: 'test', char: 'w' }),
+      },
+    };
+    it('passes', async () => {
+      const out = await Parser.parse(['--wait=10'], buildProps);
+      expect(out.flags.wait.quantity).to.equal(10);
+      expect(out.flags.wait.unit).to.equal(Duration.Unit.HOURS);
+    });
+    it('passes with default', async () => {
+      const out = await Parser.parse([], buildProps);
+      expect(out.flags.wait).to.equal(undefined);
+    });
+  });
+
+  describe('validation with no options and weeks unit', () => {
+    const defaultValue = 33;
+    const buildProps = {
+      flags: {
+        wait: buildDurationFlag({
+          unit: 'weeks',
+          defaultValue,
+        })({ description: 'test', char: 'w' }),
+      },
+    };
+    it('passes', async () => {
+      const out = await Parser.parse(['--wait=10'], buildProps);
+      expect(out.flags.wait.quantity).to.equal(10);
+      expect(out.flags.wait.unit).to.equal(Duration.Unit.WEEKS);
+    });
+    it('passes with default', async () => {
+      const out = await Parser.parse([], buildProps);
+      expect(out.flags.wait.quantity).to.equal(33);
+    });
+  });
+
+  describe('validation with all options', () => {
+    const min = 1;
+    const max = 60;
+    const defaultValue = 33;
+    const buildProps = {
+      flags: {
+        wait: buildDurationFlag({
+          defaultValue,
+          min,
+          max,
+          unit: 'minutes',
+        })({ description: 'test', char: 'w' }),
+      },
+    };
+    it('passes', async () => {
+      const out = await Parser.parse(['--wait=10'], buildProps);
+      expect(out.flags.wait.quantity).to.equal(10);
+    });
+    it('min passes', async () => {
+      const out = await Parser.parse([`--wait=${min}`], buildProps);
+      expect(out.flags.wait.quantity).to.equal(min);
+    });
+    it('max passes', async () => {
+      const out = await Parser.parse([`--wait=${max}`], buildProps);
+      expect(out.flags.wait.quantity).to.equal(max);
+    });
+    it('default works', async () => {
+      const out = await Parser.parse([], buildProps);
+      expect(out.flags.wait.quantity).to.equal(defaultValue);
+    });
+    describe('failures', () => {
+      it('below min fails', async () => {
+        try {
+          const out = await Parser.parse([`--wait=${min - 1}`], buildProps);
+
+          throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+        } catch (err) {
+          const error = err as Error;
+          expect(error.message).to.equal(messages.getMessage('flags.duration.errors.DurationBounds', [1, 60]));
+        }
+      });
+      it('above max fails', async () => {
+        try {
+          const out = await Parser.parse([`--wait=${max + 1}`], buildProps);
+          throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+        } catch (err) {
+          const error = err as Error;
+          expect(error.message).to.equal(messages.getMessage('flags.duration.errors.DurationBounds', [1, 60]));
+        }
+      });
+      it('invalid input', async () => {
+        try {
+          const out = await Parser.parse(['--wait=abc}'], buildProps);
+          throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+        } catch (err) {
+          const error = err as Error;
+          expect(error.message).to.equal(messages.getMessage('flags.duration.errors.InvalidInput'));
+        }
+      });
+    });
+  });
+});

--- a/test/unit/flags/fsFlags.test.ts
+++ b/test/unit/flags/fsFlags.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as fs from 'fs';
+import { expect } from 'chai';
+import { Parser } from '@oclif/core';
+import { Messages } from '@salesforce/core';
+import * as sinon from 'sinon';
+import { existingDirectory, existingFile } from '../../../src/flags/fsFlags';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
+
+describe('fs flags', () => {
+  const sandbox = sinon.createSandbox();
+  let existsStub: sinon.SinonStub;
+  let statStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    existsStub = sandbox.stub(fs, 'existsSync');
+    statStub = sandbox.stub(fs.promises, 'stat');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('directory', () => {
+    const testDir = 'some/dir';
+    it('passes when dir exists', async () => {
+      existsStub.returns(true);
+      statStub.returns({ isDirectory: () => true });
+      const out = await Parser.parse([`--dir=${testDir}`], {
+        flags: { dir: existingDirectory() },
+      });
+      expect(out.flags).to.deep.include({ dir: testDir });
+    });
+    it("fails when dir doesn't exist", async () => {
+      existsStub.returns(false);
+      try {
+        const out = await Parser.parse([`--dir=${testDir}`], {
+          flags: { dir: existingDirectory() },
+        });
+        throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+      } catch (err) {
+        const error = err as Error;
+        expect(error.message).to.equal(
+          messages.getMessage('flags.existingDirectory.errors.MissingDirectory', [testDir])
+        );
+      }
+    });
+    it('fails when dir exists but is not a dir', async () => {
+      existsStub.returns(true);
+      statStub.returns({ isDirectory: () => false });
+      try {
+        const out = await Parser.parse([`--dir=${testDir}`], {
+          flags: { dir: existingDirectory() },
+        });
+        throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+      } catch (err) {
+        const error = err as Error;
+        expect(error.message).to.equal(
+          messages.getMessage('flags.existingDirectory.errors.MissingDirectory', [testDir])
+        );
+      }
+    });
+  });
+
+  describe('file', () => {
+    const testFile = 'some/file.ext';
+    it('passes when file exists', async () => {
+      existsStub.returns(true);
+      statStub.returns({ isFile: () => true });
+      const out = await Parser.parse([`--file=${testFile}`], {
+        flags: { file: existingFile() },
+      });
+      expect(out.flags).to.deep.include({ file: testFile });
+    });
+    it("fails when dir doesn't exist", async () => {
+      existsStub.returns(false);
+      try {
+        const out = await Parser.parse([`--file=${testFile}`], {
+          flags: { file: existingFile() },
+        });
+        throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+      } catch (err) {
+        const error = err as Error;
+        expect(error.message).to.equal(messages.getMessage('flags.existingFile.errors.MissingFile', [testFile]));
+      }
+    });
+    it('fails when file exists but is not a file', async () => {
+      existsStub.returns(true);
+      statStub.returns({ isFile: () => false });
+      try {
+        const out = await Parser.parse([`--file=${testFile}`], {
+          flags: { file: existingFile() },
+        });
+        throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+      } catch (err) {
+        const error = err as Error;
+        expect(error.message).to.equal(messages.getMessage('flags.existingFile.errors.NotAFile', [testFile]));
+      }
+    });
+  });
+});

--- a/test/unit/flags/id.test.ts
+++ b/test/unit/flags/id.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from 'chai';
+import { Parser } from '@oclif/core';
+import { Messages } from '@salesforce/core';
+import { buildIdFlag } from '../../../src/flags/salesforceId';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
+
+describe('id flag', () => {
+  const id15 = '123456789012345';
+  const id18 = '123456789012345678';
+  const id16 = '1234567890123456';
+
+  it('allows 15 or 18 when no length specified', async () => {
+    const out = await Parser.parse([`--id=${id15}`], {
+      flags: { id: buildIdFlag({})() },
+    });
+    expect(out.flags).to.deep.include({ id: id15 });
+  });
+
+  it('throws on invalid length id', async () => {
+    try {
+      const out = await Parser.parse([`--id=${id16}`], {
+        flags: { id: buildIdFlag({})() },
+      });
+      throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).to.equal(messages.getMessage('errors.InvalidIdLength', ['15 or 18']));
+    }
+  });
+
+  it('throws on invalid characters in id', async () => {
+    try {
+      const out = await Parser.parse(['--id=???????????????'], {
+        flags: { id: buildIdFlag({})() },
+      });
+      throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).to.equal(messages.getMessage('errors.InvalidId'));
+    }
+  });
+  it('good 15', async () => {
+    const out = await Parser.parse([`--id=${id15}`], {
+      flags: { id: buildIdFlag({ length: 15 })() },
+    });
+    expect(out.flags).to.deep.include({ id: id15 });
+  });
+  it('bad 15', async () => {
+    try {
+      const out = await Parser.parse([`--id=${id18}`], {
+        flags: { id: buildIdFlag({ length: 15 })() },
+      });
+      throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).to.equal(messages.getMessage('errors.InvalidIdLength', ['15']));
+    }
+  });
+  it('good 18', async () => {
+    const out = await Parser.parse([`--id=${id18}`], {
+      flags: { id: buildIdFlag({ length: 18 })() },
+    });
+    expect(out.flags).to.deep.include({ id: id18 });
+  });
+  it('bad 18', async () => {
+    try {
+      const out = await Parser.parse([`--id=${id15}`], {
+        flags: { id: buildIdFlag({ length: 18 })() },
+      });
+      throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).to.equal(messages.getMessage('errors.InvalidIdLength', ['18']));
+    }
+  });
+  it('good startsWith', async () => {
+    const out = await Parser.parse([`--id=${id18}`], {
+      flags: { id: buildIdFlag({ startsWith: '123' })() },
+    });
+    expect(out.flags).to.deep.include({ id: id18 });
+  });
+  it('bad startsWith', async () => {
+    try {
+      const out = await Parser.parse([`--id=${id15}`], {
+        flags: { id: buildIdFlag({ startsWith: '000' })() },
+      });
+      throw new Error(`Should have thrown an error ${JSON.stringify(out)}`);
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).to.equal(messages.getMessage('errors.InvalidPrefix', ['000']));
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "./node_modules/@salesforce/dev-config/tsconfig-strict",
   "compilerOptions": {
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "declarationMap": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "test/unit/flags/id.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -457,10 +457,10 @@
     is-wsl "^2.1.1"
     tslib "^2.0.0"
 
-"@oclif/core@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/@oclif/core/-/core-1.2.0.tgz#f1110b1fe868e439f94f8b4ffad5dd8acf862294"
-  integrity sha512-h1n8NEAUzaL3+wky7W1FMeySmJWQpYX1LhWMltFY/ScvmapZzee7D9kzy/XI/ZIWWfz2ZYCTMD1wOKXO6ueynw==
+"@oclif/core@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.3.6.tgz#b3c3b3c865c33d88aa6e7f8f596a7939720c4d68"
+  integrity sha512-WSb5uyHlfTcN2HQT1miKDe90AhaiZ5Di0jmyqWlPZA0XE+xvJgMPOAyQdxxVed+XpkP6AhCPJEoIlZvQb1y1Xw==
   dependencies:
     "@oclif/linewrap" "^1.0.0"
     "@oclif/screen" "^3.0.2"


### PR DESCRIPTION
flags for use across org-related command that give us most of what we'll miss from SfdxCommand.

open questions
- `/messages` I left this in one big file.  I don't know how sf wants libraries to handle messages (multiple files? a flags folder?)
- there's two "interfaces" for these--some can be Flags and some have to be a function that returns a flag (to allow it to have parameters).  

tests
- there are no tests for OrgFlags.  I think those should probably be a NUT given the mocking complexity required to make them a UT.  Alternatively, we're about to write a ton of commands using these flags, and they'll have NUTs.  🤷🏻 
- everything else is a UT 