### PR TITLE
fix: use OptionFlag interface so that exactlyOne can be used

### DIFF
--- a/src/flags/duration.ts
+++ b/src/flags/duration.ts
@@ -13,7 +13,7 @@ const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages'
 
 type DurationUnit = Lowercase<keyof typeof Duration.Unit>;
 
-export interface DurationFlagConfig extends Partial<Interfaces.OptionFlagProps> {
+export interface DurationFlagConfig extends Partial<Interfaces.OptionFlag<Duration>> {
   unit: Required<DurationUnit>;
   defaultValue?: number;
   min?: number;

--- a/src/flags/orgFlags.ts
+++ b/src/flags/orgFlags.ts
@@ -58,7 +58,7 @@ export const optionalOrgFlag = Flags.build<Org | undefined>({
   char: 'e',
   parse: async (input: string | undefined) => await maybeGetOrg(input),
   default: async () => await maybeGetOrg(),
-  defaultHelp: async () => (await maybeGetOrg(undefined))?.getUsername(),
+  defaultHelp: async () => (await maybeGetOrg())?.getUsername(),
 });
 
 /**
@@ -83,8 +83,8 @@ export const optionalOrgFlag = Flags.build<Org | undefined>({
 export const requiredOrgFlag = Flags.build<Org>({
   char: 'e',
   parse: async (input: string | undefined) => await getOrgOrThrow(input),
-  default: async () => await getOrgOrThrow(undefined),
-  defaultHelp: async () => (await getOrgOrThrow(undefined))?.getUsername(),
+  default: async () => await getOrgOrThrow(),
+  defaultHelp: async () => (await getOrgOrThrow())?.getUsername(),
 });
 
 /**
@@ -109,6 +109,6 @@ export const requiredOrgFlag = Flags.build<Org>({
 export const requiredHubFlag = Flags.build<Org>({
   char: 'v',
   parse: async (input: string | undefined) => await getHubOrThrow(input),
-  default: async () => await getHubOrThrow(undefined),
-  defaultHelp: async () => (await getHubOrThrow(undefined))?.getUsername(),
+  default: async () => await getHubOrThrow(),
+  defaultHelp: async () => (await getHubOrThrow())?.getUsername(),
 });

--- a/src/flags/salesforceId.ts
+++ b/src/flags/salesforceId.ts
@@ -10,7 +10,7 @@ import { Messages, sfdc } from '@salesforce/core';
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
 
-export interface IdFlagConfig extends Partial<Interfaces.OptionFlagProps> {
+export interface IdFlagConfig extends Partial<Interfaces.OptionFlag<string>> {
   /**
    * Can specify if the version must be 15 or 18 characters long.  Leave blank to allow either 15 or 18.
    */


### PR DESCRIPTION
Special flags should extend `Interfaces.OptionFlag` so that they can use the `exactlyOne` property

[skip-validate-pr]