### PR TITLE
fix: log errors to stderr

### DIFF
--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -241,9 +241,11 @@ export abstract class SfCommand<T> extends Command {
 
   protected async catch(error: SfCommand.Error): Promise<SfCommand.Error> {
     process.exitCode = process.exitCode ?? error.exitCode ?? 1;
-    this.log(this.formatError(error));
     if (this.jsonEnabled()) {
       CliUx.ux.styledJSON(this.toErrorJson(error));
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(this.formatError(error));
     }
     return error;
   }


### PR DESCRIPTION
Log errors to stderr. Doing so fixes various NUTs that were running assertions on the content in stderr

[skip-validate-pr]