### PR TITLE
feat: warn users when using a beta command

### DIFF
--- a/messages/messages.md
+++ b/messages/messages.md
@@ -73,3 +73,7 @@ Info:
 # actions.tryThis
 
 Try this:
+
+# warning.CommandInBeta
+
+This command is currently in beta. Any aspect of this command can change without advanced notice. Don't use beta commands in your scripts.

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -194,9 +194,13 @@ export abstract class SfCommand<T> extends Command {
   ): Promise<R> {
     return this.prompter.timedPrompt(questions, ms, initialAnswers);
   }
+
   public async _run<R>(): Promise<R | undefined> {
     if (this.statics.requiresProject) {
       this.project = await this.assignProject();
+    }
+    if (this.statics.state === 'beta') {
+      this.warn(messages.getMessage('warning.CommandInBeta'));
     }
     this.lifecycle.onWarning(async (warning: string) => {
       this.warn(warning);


### PR DESCRIPTION
Warn users if they're using a beta command:

```
~/repos/salesforcecli/sample-project-multiple-packages [main] : ~/repos/salesforcecli/plugin-deploy-retrieve/bin/dev deploy metadata validate -d force-app
Warning: This command is currently in beta. Any aspect of this command is likely to change without advanced notice. Please do not rely on beta commands for scripting.
```

@W-10895477@