### PR TITLE
feat: support error codes help section

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "/messages"
   ],
   "dependencies": {
-    "@oclif/core": "^1.6.0",
-    "@salesforce/core": "^3.7.9",
+    "@oclif/core": "^1.6.3",
+    "@salesforce/core": "^3.11.0",
     "@salesforce/kit": "^1.5.34",
     "@salesforce/ts-types": "^1.5.20",
     "chalk": "^2.4.2",

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,27 +30,31 @@ export type HelpSection = {
  */
 export function toHelpSection(
   header: string,
-  ...vars: Array<OrgConfigProperties | SfdxPropertyKeys | EnvironmentVariable | string>
+  ...vars: Array<OrgConfigProperties | SfdxPropertyKeys | EnvironmentVariable | string | Record<string, string>>
 ): HelpSection {
   const body = vars
-    .map((v) => {
-      const orgConfig = ORG_CONFIG_ALLOWED_PROPERTIES.find(({ key }) => {
-        return key === v;
-      });
-      if (orgConfig) {
-        return { name: orgConfig.key, description: orgConfig.description };
-      }
-      const sfdxProperty = SFDX_ALLOWED_PROPERTIES.find(({ key }) => key === v);
-      if (sfdxProperty) {
-        return { name: sfdxProperty.key.valueOf(), description: sfdxProperty.description };
-      }
-      const envVar = Object.entries(SUPPORTED_ENV_VARS).find(([k]) => k === v);
+    .flatMap((v) => {
+      if (typeof v === 'string') {
+        const orgConfig = ORG_CONFIG_ALLOWED_PROPERTIES.find(({ key }) => {
+          return key === v;
+        });
+        if (orgConfig) {
+          return { name: orgConfig.key, description: orgConfig.description };
+        }
+        const sfdxProperty = SFDX_ALLOWED_PROPERTIES.find(({ key }) => key === v);
+        if (sfdxProperty) {
+          return { name: sfdxProperty.key.valueOf(), description: sfdxProperty.description };
+        }
+        const envVar = Object.entries(SUPPORTED_ENV_VARS).find(([k]) => k === v);
 
-      if (envVar) {
-        const [eKey, data] = envVar;
-        return { name: eKey, description: data.description };
+        if (envVar) {
+          const [eKey, data] = envVar;
+          return { name: eKey, description: data.description };
+        }
+        return undefined;
+      } else {
+        return Object.entries(v).map(([name, description]) => ({ name, description }));
       }
-      return undefined;
     })
     .filter((b) => b);
   return { header, body };

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -26,6 +26,7 @@ describe('toHelpSection', () => {
       description: SUPPORTED_ENV_VARS[EnvironmentVariable.SFDX_ACCESS_TOKEN].description,
     });
   });
+
   it('should produce help section for org config vars', () => {
     const orgConfigSection = toHelpSection('ORG CONFIG VAR SECTION', OrgConfigProperties.TARGET_ORG);
     expect(orgConfigSection).to.have.property('header', 'ORG CONFIG VAR SECTION');
@@ -36,6 +37,7 @@ describe('toHelpSection', () => {
       description: orgConfig.description,
     });
   });
+
   it('should produce help section for sfdx config vars', () => {
     const sfdxConfigSection = toHelpSection('SFDX CONFIG VAR SECTION', SfdxPropertyKeys.INSTANCE_URL);
     expect(sfdxConfigSection).to.have.property('header', 'SFDX CONFIG VAR SECTION');
@@ -46,6 +48,7 @@ describe('toHelpSection', () => {
       description: sfdxConfig.description,
     });
   });
+
   it('should produce help section for mixed config vars', () => {
     const mixedSection = toHelpSection(
       'MIXED VAR SECTION',
@@ -71,5 +74,15 @@ describe('toHelpSection', () => {
         description: sfdxConfig.description,
       },
     ]);
+  });
+
+  it('should produce help section for arbitrary data', () => {
+    const envVarSection = toHelpSection('ARBITRARY SECTION', { 'foo bar': 'hello world' });
+    expect(envVarSection).to.have.property('header', 'ARBITRARY SECTION');
+    expect(envVarSection).to.have.property('body').to.have.property('length', 1);
+    expect(envVarSection.body[0]).to.deep.equal({
+      name: 'foo bar',
+      description: 'hello world',
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -492,10 +492,10 @@
     widest-line "^3.1.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/core@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.6.0.tgz#a91333275cd43a49097158f4ae8e15ccf718bd48"
-  integrity sha512-JHerjgRd29EtUVpDIrzohq2XdxJfgmZVGHAFlf75QVhLGFaleopZAQNBXkHkxG//kGib0LhyVGW7azcFKzr1eQ==
+"@oclif/core@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.npmjs.org/@oclif/core/-/core-1.6.3.tgz#3d1dd4e033f5512ac35963a73878257142390838"
+  integrity sha512-a3DrPNlOYemwnzxuJ3tINjqpMVIYe56Mg+XaQo0nGsqGSk69wF5Q/hD8plsWrtwdkeIxwxhgl7T699EJypAUwg==
   dependencies:
     "@oclif/linewrap" "^1.0.0"
     "@oclif/screen" "^3.0.2"
@@ -618,10 +618,10 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/core@^3.7.9":
-  version "3.7.9"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.7.9.tgz#bcef443046e8680bf80c31a3d0a0740e1d83314e"
-  integrity sha512-yR+0DKWH55T/tU1y55VVFm9s5B8eMIZdVXch/b1FeFfEpycF/tYbbUcsSyV+oo8xEsJ6lxNj+P9m41izoWh2Sw==
+"@salesforce/core@^3.11.0":
+  version "3.11.0"
+  resolved "https://registry.npmjs.org/@salesforce/core/-/core-3.11.0.tgz#e1ec10189103a9133117af938156fb9f3eb2aef2"
+  integrity sha512-OqEkFfgfL2WvuzasjgrsGVa2SB00FCdfu09hPBK3URnR418+ztk283TDNOQ15AGW5oI8EWdEEKpOI+oAXmWS3A==
   dependencies:
     "@oclif/core" "^1.5.1"
     "@salesforce/bunyan" "^2.0.0"


### PR DESCRIPTION
Allow commands to generate help sections with arbitrary data. This is primarily to support the error codes section of help

```typescript
export default class DeployMetadata extends SfCommand<DeployMetadataResult> {
  public static errorCodes = toHelpSection('ERROR CODES', {
    0: 'The deploy succeeded.',
    1: 'The deploy failed.',
  });
}
```

```
ERROR CODES
  0 The deploy succeeded.
  1  The deploy failed.
```