### PR TITLE
Sm/external nuts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   release-management: salesforce/npm-release-management@4
 
+jobs:
   external-nut:
     description: Runs NUTs from other (external) repos by cloning them.  Substitutes a dependency for the current pull request.  For example, you're testing a PR to a library and want to test a plugin in another repo that uses the library.
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ orbs:
       - run:
           name: Install dependencies
           command: yarn
-      - run: yarn remove @salesforce/source-deploy-retrieve
+      - run: yarn remove @salesforce/sf-plugins-core
       # windows/powershell does envs differently so we have to have conditional steps
       - when:
           condition:
@@ -74,16 +74,10 @@ orbs:
             - run: yarn add $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME#$CIRCLE_SHA1
       - run:
           name: install/build <<parameters.external_project_git_url>> in node_modules
-          # why doesn't SDR put the metadataRegistry.json in the lib when run from inside a node module?  I don't know.
-          # prevent dependency conflicts between plugin's top-level imports and imported SDR's deps by deleting them
-          # If there are real conflicts, we'll catch them when bumping a version in the plugin (same nuts)
           command: |
             yarn install
-            npm install shx -g
-            shx rm -rf node_modules/@salesforce/sf-plugins-core
             yarn build
-            cp src/registry/metadataRegistry.json lib/src/registry
-          working_directory: node_modules/@salesforce/source-deploy-retrieve
+          working_directory: node_modules/@salesforce/$CIRCLE_PROJECT_REPONAME
       - run:
           name: Build the external project
           command: |
@@ -97,19 +91,19 @@ workflows:
   version: 2
   test-and-release:
     jobs:
-      - release-management/validate-pr:
-          filters:
-            branches:
-              ignore: main
-      - release-management/test-package:
-          matrix:
-            parameters:
-              os:
-                - linux
-              node_version:
-                - latest
-                - lts
-                - maintenance
+      # - release-management/validate-pr:
+      #     filters:
+      #       branches:
+      #         ignore: main
+      # - release-management/test-package:
+      #     matrix:
+      #       parameters:
+      #         os:
+      #           - linux
+      #         node_version:
+      #           - latest
+      #           - lts
+      #           - maintenance
       - external-nut:
           filters:
             branches:
@@ -117,8 +111,8 @@ workflows:
               # 1) we already ran on a branch
               # 2) they aren't required and would run in parallel to release job
               ignore: main
-          requires:
-            - release-management/test-package
+          # requires:
+          #   - release-management/test-package
           sfdx_version: latest
           size: medium
           matrix:
@@ -126,14 +120,14 @@ workflows:
               os: [windows, linux]
               node_version: [lts]
               external_project_git_url: ['https://github.com/salesforcecli/plugin-env']
-      - release-management/release-package:
-          github-release: true
-          requires:
-            - release-management/test-package
-          filters:
-            branches:
-              only: main
-          context: CLI_CTC
+      # - release-management/release-package:
+      #     github-release: true
+      #     requires:
+      #       - release-management/test-package
+      #     filters:
+      #       branches:
+      #         only: main
+      #     context: CLI_CTC
   dependabot-automerge:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,11 +74,11 @@ jobs:
           steps:
             - run: yarn add $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME#$CIRCLE_SHA1
       - run:
-          name: install/build <<parameters.external_project_git_url>> in node_modules
+          name: install/build sf-plugins-core in node_modules
           command: |
             yarn install
             yarn build
-          working_directory: node_modules/@salesforce/$CIRCLE_PROJECT_REPONAME
+          working_directory: node_modules/@salesforce/sf-plugins-core
       - run:
           name: Build the external project
           command: |
@@ -118,7 +118,8 @@ workflows:
           size: medium
           matrix:
             parameters:
-              os: [windows, linux]
+              # os: [windows, linux]
+              os: [linux]
               node_version: [lts]
               external_project_git_url: ['https://github.com/salesforcecli/plugin-env']
       # - release-management/release-package:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,7 @@ workflows:
           size: medium
           matrix:
             parameters:
-              # os: [windows, linux]
-              os: [linux]
+              os: [windows, linux]
               node_version: [lts]
               external_project_git_url: ['https://github.com/salesforcecli/plugin-env']
       # - release-management/release-package:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,10 +125,10 @@ workflows:
               os: [windows, linux]
               node_version: [lts]
               external_project_git_url:
-              [
-                'https://github.com/salesforcecli/plugin-env',
-                'https://github.com/salesforcecli/plugin-deploy-retrieve',
-              ]
+                [
+                  'https://github.com/salesforcecli/plugin-env',
+                  'https://github.com/salesforcecli/plugin-deploy-retrieve',
+                ]
       # - release-management/release-package:
       #     github-release: true
       #     requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,11 @@ workflows:
             parameters:
               os: [windows, linux]
               node_version: [lts]
-              external_project_git_url: ['https://github.com/salesforcecli/plugin-env']
+              external_project_git_url:
+              [
+                'https://github.com/salesforcecli/plugin-env',
+                'https://github.com/salesforcecli/plugin-deploy-retrieve',
+              ]
       # - release-management/release-package:
       #     github-release: true
       #     requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,19 +96,19 @@ workflows:
   version: 2
   test-and-release:
     jobs:
-      # - release-management/validate-pr:
-      #     filters:
-      #       branches:
-      #         ignore: main
-      # - release-management/test-package:
-      #     matrix:
-      #       parameters:
-      #         os:
-      #           - linux
-      #         node_version:
-      #           - latest
-      #           - lts
-      #           - maintenance
+      - release-management/validate-pr:
+          filters:
+            branches:
+              ignore: main
+      - release-management/test-package:
+          matrix:
+            parameters:
+              os:
+                - linux
+              node_version:
+                - latest
+                - lts
+                - maintenance
       - external-nut:
           filters:
             branches:
@@ -116,8 +116,8 @@ workflows:
               # 1) we already ran on a branch
               # 2) they aren't required and would run in parallel to release job
               ignore: main
-          # requires:
-          #   - release-management/test-package
+          requires:
+            - release-management/test-package
           sfdx_version: latest
           size: medium
           matrix:
@@ -127,18 +127,41 @@ workflows:
               external_project_git_url:
                 [
                   'https://github.com/salesforcecli/plugin-env',
-                  'https://github.com/salesforcecli/plugin-deploy-retrieve',
                   'https://github.com/salesforcecli/plugin-login',
                   'https://github.com/salesforcecli/plugin-generate',
                 ]
-      # - release-management/release-package:
-      #     github-release: true
-      #     requires:
-      #       - release-management/test-package
-      #     filters:
-      #       branches:
-      #         only: main
-      #     context: CLI_CTC
+      - external-nut:
+          filters:
+            branches:
+              # we don't run again on main because
+              # 1) we already ran on a branch
+              # 2) they aren't required and would run in parallel to release job
+              ignore: main
+          requires:
+            - release-management/test-package
+          sfdx_version: latest
+          size: medium
+          matrix:
+            parameters:
+              os: [windows, linux]
+              node_version: [lts]
+              external_project_git_url: ['https://github.com/salesforcecli/plugin-deploy-retrieve']
+              test_command:
+                [
+                  'yarn test:nuts:deploy:metadata:manifest',
+                  'yarn test:nuts:deploy:metadata:metadata',
+                  'yarn test:nuts:deploy:metadata:source-dir',
+                  'yarn test:nuts:deploy:metadata:test-level',
+                  'yarn test:nuts:static',
+                ]
+      - release-management/release-package:
+          github-release: true
+          requires:
+            - release-management/test-package
+          filters:
+            branches:
+              only: main
+          context: CLI_CTC
   dependabot-automerge:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,8 @@ workflows:
                 [
                   'https://github.com/salesforcecli/plugin-env',
                   'https://github.com/salesforcecli/plugin-deploy-retrieve',
+                  'https://github.com/salesforcecli/plugin-login',
+                  'https://github.com/salesforcecli/plugin-generate',
                 ]
       # - release-management/release-package:
       #     github-release: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,10 @@ jobs:
           name: install/build sf-plugins-core in node_modules
           command: |
             yarn install
+            npm install shx -g
+            shx rm -rf node_modules/@oclif/core
+            shx rm -rf node_modules/@salesforce/core
+            shx rm -rf node_modules/@salesforce/kit
             yarn build
           working_directory: node_modules/@salesforce/sf-plugins-core
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,97 @@ version: 2.1
 orbs:
   release-management: salesforce/npm-release-management@4
 
+  external-nut:
+    description: Runs NUTs from other (external) repos by cloning them.  Substitutes a dependency for the current pull request.  For example, you're testing a PR to a library and want to test a plugin in another repo that uses the library.
+
+    parameters:
+      test_command:
+        type: string
+        description: 'command to execute (ex: yarn test:nuts)'
+        default: 'yarn test:nuts'
+      node_version:
+        description: version of node to run tests against
+        type: string
+        default: 'lts'
+      os:
+        description: operating system to run tests on
+        type: enum
+        enum: ['linux', 'windows']
+        default: 'linux'
+      sfdx_version:
+        description: 'By default, the latest version of the standalone CLI will be installed. To install via npm, supply a version tag such as "latest" or "6".'
+        default: ''
+        type: string
+      sfdx_executable_path:
+        description: "Path to sfdx executable to be used by NUTs, defaults to ''"
+        default: ''
+        type: string
+      external_project_git_url:
+        description: 'The url that will be cloned.  This contains the NUTs you want to run.  Ex: https://github.com/salesforcecli/plugin-user'
+        type: string
+        default: ''
+      size:
+        type: enum
+        description: |
+          The size of machine resource to use. Defaults to medium.
+        default: medium
+        enum:
+          - medium
+          - large
+          - xlarge
+          - 2xlarge
+
+    executor:
+      name: release-management/<< parameters.os >>
+      size: << parameters.size >>
+
+    environment:
+      TESTKIT_EXECUTABLE_PATH: <<parameters.sfdx_executable_path>>
+
+    steps:
+      - release-management/install-node:
+          version: <<parameters.node_version>>
+          os: <<parameters.os>>
+      - release-management/install-sfdx:
+          version: <<parameters.sfdx_version>>
+          os: <<parameters.os>>
+      - run: git clone <<parameters.external_project_git_url>> $(pwd)
+      - run:
+          name: Install dependencies
+          command: yarn
+      - run: yarn remove @salesforce/source-deploy-retrieve
+      # windows/powershell does envs differently so we have to have conditional steps
+      - when:
+          condition:
+            equal: ['windows', <<parameters.os>>]
+          steps:
+            - run: yarn add $env:CIRCLE_PROJECT_USERNAME/$env:CIRCLE_PROJECT_REPONAME#$env:CIRCLE_SHA1
+      - when:
+          condition:
+            equal: ['linux', <<parameters.os>>]
+          steps:
+            - run: yarn add $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME#$CIRCLE_SHA1
+      - run:
+          name: install/build <<parameters.external_project_git_url>> in node_modules
+          # why doesn't SDR put the metadataRegistry.json in the lib when run from inside a node module?  I don't know.
+          # prevent dependency conflicts between plugin's top-level imports and imported SDR's deps by deleting them
+          # If there are real conflicts, we'll catch them when bumping a version in the plugin (same nuts)
+          command: |
+            yarn install
+            npm install shx -g
+            shx rm -rf node_modules/@salesforce/sf-plugins-core
+            yarn build
+            cp src/registry/metadataRegistry.json lib/src/registry
+          working_directory: node_modules/@salesforce/source-deploy-retrieve
+      - run:
+          name: Build the external project
+          command: |
+            yarn build
+      - run:
+          name: Nuts
+          command: |
+            <<parameters.test_command>>
+
 workflows:
   version: 2
   test-and-release:
@@ -19,6 +110,22 @@ workflows:
                 - latest
                 - lts
                 - maintenance
+      - external-nut:
+          filters:
+            branches:
+              # we don't run again on main because
+              # 1) we already ran on a branch
+              # 2) they aren't required and would run in parallel to release job
+              ignore: main
+          requires:
+            - release-management/test-package
+          sfdx_version: latest
+          size: medium
+          matrix:
+            parameters:
+              os: [windows, linux]
+              node_version: [lts]
+              external_project_git_url: ['https://github.com/salesforcecli/plugin-env']
       - release-management/release-package:
           github-release: true
           requires:


### PR DESCRIPTION
NOTE: requires https://github.com/salesforcecli/plugin-deploy-retrieve/pull/237 (new npm script)

run external NUTs to catch breaking changes in library
parallelize the slower deploy/retrieve NUTs

[@W-10909105@](https://gus.lightning.force.com/a07EE00000to0oUYAQ)  