### PR TITLE
fix: prevent multiple starts of progress bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@oclif/core": "^1.7.0",
     "@salesforce/core": "^3.15.5",
-    "@salesforce/kit": "^1.5.34",
+    "@salesforce/kit": "^1.5.41",
     "@salesforce/ts-types": "^1.5.20",
     "chalk": "^4",
     "inquirer": "^8.2.0"

--- a/src/ux/progress.ts
+++ b/src/ux/progress.ts
@@ -24,6 +24,7 @@ export class Progress extends UxBase {
 
   private bar!: Progress.Bar;
   private total!: number;
+  private started = false;
 
   public constructor(outputEnabled: boolean) {
     super(outputEnabled);
@@ -86,12 +87,15 @@ export class Progress extends UxBase {
   }
 
   private _start(total: number, payload: Progress.Payload = {}): void {
+    if (this.started) return;
     const start = once((bar: Progress.Bar, t: number, p: Progress.Payload = {}) => {
       bar.start(t);
       if (Object.keys(p).length) {
         bar.update(0, p);
       }
     });
+
+    this.started = true;
     start(this.bar, total, payload);
   }
 }

--- a/src/ux/progress.ts
+++ b/src/ux/progress.ts
@@ -60,7 +60,7 @@ export class Progress extends UxBase {
 
       this.bar.setTotal(total);
       this.bar.start(total);
-      if (Object.keys(payload)) {
+      if (Object.keys(payload).length) {
         this.bar.update(0, payload);
       }
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,6 +697,15 @@
     shx "^0.3.3"
     tslib "^2.2.0"
 
+"@salesforce/kit@^1.5.41":
+  version "1.5.41"
+  resolved "https://registry.npmjs.org/@salesforce/kit/-/kit-1.5.41.tgz#3248d4d28fe24ed47827716cfe416c21a2a90651"
+  integrity sha512-nhi7jw3LNITl7rHSnCLnEDTaq6nvolSMFBg7poniG84Q7kJPezgTEj5OKAyQ9hJoRE4u59n5M5bUFvwRoXmJzQ==
+  dependencies:
+    "@salesforce/ts-types" "^1.5.20"
+    shx "^0.3.3"
+    tslib "^2.2.0"
+
 "@salesforce/prettier-config@^0.0.2":
   version "0.0.2"
   resolved "https://registry.npmjs.org/@salesforce/prettier-config/-/prettier-config-0.0.2.tgz#ded39bf7cb75238edc9db6dd093649111350f8bc"


### PR DESCRIPTION
Prevent multiple calls to `this.start` on the same instance of `Progress`. This resolves the issue of the deploy commands hanging indefinitely.

@W-10877276@