### PR TITLE
feat: catch method supports base and SfError

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "/messages"
   ],
   "dependencies": {
-    "@oclif/core": "^1.7.0",
+    "@oclif/core": "^1.9.0",
     "@salesforce/core": "^3.15.5",
     "@salesforce/kit": "^1.5.41",
     "@salesforce/ts-types": "^1.5.20",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "@oclif/core": "^1.9.0",
-    "@salesforce/core": "^3.15.5",
+    "@salesforce/core": "^3.19.2",
     "@salesforce/kit": "^1.5.41",
     "@salesforce/ts-types": "^1.5.20",
     "chalk": "^4",

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -14,6 +14,7 @@ import {
   Lifecycle,
   Mode,
   EnvironmentVariable,
+  SfError,
 } from '@salesforce/core';
 import { AnyJson } from '@salesforce/ts-types';
 import * as chalk from 'chalk';
@@ -238,12 +239,9 @@ export abstract class SfCommand<T> extends Command {
   /**
    * Wrap the command error into the standardized JSON structure.
    */
-  protected toErrorJson(error: Error): SfCommand.Error {
+  protected toErrorJson(error: SfCommand.Error): SfCommand.Error {
     return {
-      status: process.exitCode ?? 1,
-      stack: error.stack,
-      name: error.name,
-      message: error.message,
+      ...error,
       warnings: this.warnings,
     };
   }
@@ -259,15 +257,23 @@ export abstract class SfCommand<T> extends Command {
     }
   }
 
-  protected async catch(error: SfCommand.Error): Promise<SfCommand.Error> {
-    process.exitCode = process.exitCode ?? error.exitCode ?? 1;
+  protected async catch(error: Error | SfError | SfCommand.Error): Promise<SfCommand.Error> {
+    // transform an unknown error into one that conforms to the interface
+    const codeFromError = error instanceof SfError ? error.exitCode : 1;
+    process.exitCode ??= codeFromError;
+    const sfCommandError = {
+      ...error,
+      status: process.exitCode,
+      stack: error.stack,
+    };
+
     if (this.jsonEnabled()) {
-      CliUx.ux.styledJSON(this.toErrorJson(error));
+      CliUx.ux.styledJSON(this.toErrorJson(sfCommandError));
     } else {
       // eslint-disable-next-line no-console
-      console.error(this.formatError(error));
+      console.error(this.formatError(sfCommandError));
     }
-    return error;
+    return sfCommandError;
   }
 
   /**
@@ -334,5 +340,6 @@ export namespace SfCommand {
     actions?: string[];
     code?: unknown;
     exitCode?: number;
+    data?: unknown;
   }
 }

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -261,10 +261,19 @@ export abstract class SfCommand<T> extends Command {
     // transform an unknown error into one that conforms to the interface
     const codeFromError = error instanceof SfError ? error.exitCode : 1;
     process.exitCode ??= codeFromError;
-    const sfCommandError = {
-      ...error,
-      status: process.exitCode,
-      stack: error.stack,
+    const sfErrorProperties =
+      error instanceof SfError
+        ? { data: error.data, actions: error.actions, code: codeFromError, context: error.context }
+        : {};
+    const sfCommandError: SfCommand.Error = {
+      ...sfErrorProperties,
+      ...{
+        message: error.message,
+        name: error.name ?? 'Error',
+        status: process.exitCode,
+        stack: error.stack,
+        exitCode: process.exitCode,
+      },
     };
 
     if (this.jsonEnabled()) {
@@ -341,5 +350,6 @@ export namespace SfCommand {
     code?: unknown;
     exitCode?: number;
     data?: unknown;
+    context?: string;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,13 +617,13 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/core@^3.15.5":
-  version "3.15.5"
-  resolved "https://registry.npmjs.org/@salesforce/core/-/core-3.15.5.tgz#4109ca0a6e0c1ce28e5fb698feb4154d654b51c7"
-  integrity sha512-BAXi67C+2UcxZFnGSrzgw/4tcOPH4TxSEM0E+efwHWa6qHSPn9bjp6mO4Mtcrg9xCcM7NRbdco1mfWdZTv3mWw==
+"@salesforce/core@^3.19.2":
+  version "3.19.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.19.2.tgz#45b55fec4425ec9a447aba682a0add084c8ba73a"
+  integrity sha512-uz2ehET9zz8WJj9Gicui3zxSN34TsmjgxrP22XCdQS7/GNhye1SlV8a6ayyQLqJbYlANrPFAs1RhF6LV1mPokg==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
-    "@salesforce/kit" "^1.5.34"
+    "@salesforce/kit" "^1.5.41"
     "@salesforce/schemas" "^1.1.0"
     "@salesforce/ts-types" "^1.5.20"
     "@types/graceful-fs" "^4.1.5"
@@ -637,7 +637,7 @@
     form-data "^4.0.0"
     graceful-fs "^4.2.9"
     js2xmlparser "^4.0.1"
-    jsforce "2.0.0-beta.7"
+    jsforce "2.0.0-beta.10"
     jsonwebtoken "8.5.1"
     mkdirp "1.0.4"
     ts-retry-promise "^0.6.0"
@@ -686,15 +686,6 @@
     typedoc "0.18.0"
     typedoc-plugin-external-module-name "~4.0.0"
     typescript "^4.1.3"
-
-"@salesforce/kit@^1.5.34":
-  version "1.5.34"
-  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.5.34.tgz#7967c3f0ba8caccc0718077193d9cbebe1816871"
-  integrity sha512-vd3f9bwdx8GxAwJpfhzVQAnO82YxbaPLcYiRTS9qmo5mFnhOKsMvbjNQz/wtT4AFs2sC3yyCzvq5Vq6rAcMc7w==
-  dependencies:
-    "@salesforce/ts-types" "^1.5.20"
-    shx "^0.3.3"
-    tslib "^2.2.0"
 
 "@salesforce/kit@^1.5.41":
   version "1.5.41"
@@ -3591,10 +3582,10 @@ jsesc@^2.5.1:
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-jsforce@2.0.0-beta.7:
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.7.tgz#5d594b1b280f1ee37992b75220b4c7701a1e536c"
-  integrity sha512-aiJRbf6v0eQSJLpAg4aEB/yXsQwV9WM3ewT2v/WTLmeeZQ4ZtwlcJhQCTwW4tKX/S8U+t5nL+Iluz8jFSZFqnA==
+jsforce@2.0.0-beta.10:
+  version "2.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.10.tgz#c33fee5dd01c96d121235cffb8fee1458a35423e"
+  integrity sha512-AFigJHQocj8t36Eu+9XffoKoC2FO4/uMDMg08TfTXgvIp53lzvnQJoQrhEnwnKReof4tO2d+7j+d1QyiOa2yGg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"
@@ -3606,6 +3597,7 @@ jsforce@2.0.0-beta.7:
     csv-parse "^4.8.2"
     csv-stringify "^5.3.4"
     faye "^1.4.0"
+    form-data "^4.0.0"
     fs-extra "^8.1.0"
     https-proxy-agent "^5.0.0"
     inquirer "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -492,10 +492,10 @@
     widest-line "^3.1.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/core@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/@oclif/core/-/core-1.7.0.tgz#3b763b53eafa9afbb13cf7cdfeac0f8ddd8ab1af"
-  integrity sha512-I4q4qgtnNG7ef4sBDrJhwADdi7RExQV7LnflnXaWZZDiUoqF9AdOjC4jjx40MK0rRrCehCUtPNZBcr3WmxuS4Q==
+"@oclif/core@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.9.0.tgz#bb2a7820a9176f28921f449c0f577d39c15e74d0"
+  integrity sha512-duvlaRQf4JM+mKuwwos1DNa/Q9x6tnF3khV5RU0fy5hhETF7THlTmxioKlIvKMyQDVpySqtZXZ0OKHeCi2EWuQ==
   dependencies:
     "@oclif/linewrap" "^1.0.0"
     "@oclif/screen" "^3.0.2"
@@ -505,7 +505,7 @@
     chalk "^4.1.2"
     clean-stack "^3.0.1"
     cli-progress "^3.10.0"
-    debug "^4.3.3"
+    debug "^4.3.4"
     ejs "^3.1.6"
     fs-extra "^9.1.0"
     get-package-type "^0.1.0"
@@ -514,11 +514,10 @@
     indent-string "^4.0.0"
     is-wsl "^2.2.0"
     js-yaml "^3.14.1"
-    lodash "^4.17.21"
     natural-orderby "^2.0.3"
     object-treeify "^1.1.33"
     password-prompt "^1.1.2"
-    semver "^7.3.5"
+    semver "^7.3.7"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
     supports-color "^8.1.1"
@@ -1941,6 +1940,13 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -5018,6 +5024,13 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
 
 sentence-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
for plugins to override the `catch` method, they need to catch errors that might occur (base js Error class or SfError) rather than the interface here (which should be the output).

required for @W-10749124@