### PR TITLE
fix: parse varargs response type

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -62,8 +62,8 @@ export function toHelpSection(
   return { header, body };
 }
 
-export function parseVarArgs(args: Record<string, unknown>, argv: string[]): Record<string, unknown> {
-  const final: Record<string, unknown> = {};
+export function parseVarArgs(args: Record<string, unknown>, argv: string[]): Record<string, string | undefined> {
+  const final: Record<string, string | undefined> = {};
   const argVals = Object.values(args);
 
   // Remove arguments from varargs

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -93,6 +93,16 @@ describe('parseVarArgs', () => {
     expect(varargs).to.deep.equal({ key1: 'value1' });
   });
 
+  it('should parse multiple varargs', () => {
+    const varargs = parseVarArgs({}, ['key1=value1', 'key2=value2']);
+    expect(varargs).to.deep.equal({ key1: 'value1', key2: 'value2' });
+  });
+
+  it('should allow an empty value', () => {
+    const varargs = parseVarArgs({}, ['key1=']);
+    expect(varargs).to.deep.equal({ key1: undefined });
+  });
+
   it('should parse varargs and not arguments', () => {
     const varargs = parseVarArgs({ arg1: 'foobar' }, ['foobar', 'key1=value1']);
     expect(varargs).to.deep.equal({ key1: 'value1' });


### PR DESCRIPTION
When I looked into this a bit more, I don't think a Generic is the correct solution for this. `argv` is always going to be an array of strings based on the [type in the ParseOutput](https://github.com/oclif/core/blob/main/src/interfaces/parser.ts#L59). Since we are returning parsed `argv` values, we can assume they'll be a string (or `undefined` set by this validator util if a value is not provided). 

Let me know if you feel I am missing something. 