### PR TITLE
feat: export Ux and add configAggregator to SfCommand

### DIFF
--- a/src/exported.ts
+++ b/src/exported.ts
@@ -10,7 +10,7 @@ import { Flags as OclifFlags } from '@oclif/core';
 export { toHelpSection, parseVarArgs } from './util';
 export { Deployable, Deployer, DeployerResult } from './deployer';
 export { Deauthorizer } from './deauthorizer';
-export { Progress, Prompter, generateTableChoices } from './ux';
+export { Progress, Prompter, generateTableChoices, Ux } from './ux';
 export { SfHook } from './hooks';
 export * from './types';
 export { SfCommand, SfCommandInterface, StandardColors } from './sfCommand';

--- a/src/flags/duration.ts
+++ b/src/flags/duration.ts
@@ -42,7 +42,8 @@ export type DurationFlagConfig = {
  */
 export const durationFlag = Flags.custom<Duration, DurationFlagConfig>({
   parse: async (input, _, opts) => validate(input, opts),
-  default: async (context) => context.options.defaultValue ? toDuration(context.options.defaultValue, context.options.unit) : undefined,
+  default: async (context) =>
+    context.options.defaultValue ? toDuration(context.options.defaultValue, context.options.unit) : undefined,
 });
 
 const validate = (input: string, config: DurationFlagConfig): Duration => {

--- a/src/ux/ux.ts
+++ b/src/ux/ux.ts
@@ -8,10 +8,20 @@
 import { CliUx } from '@oclif/core';
 import { AnyJson } from '@salesforce/ts-types';
 import { UxBase } from './base';
+import { Prompter } from './prompter';
+import { Spinner } from './spinner';
 
+/**
+ * UX methods for plugins. Automatically suppress console output if outputEnabled is set to false.
+ */
 export class Ux extends UxBase {
+  public spinner: Spinner;
+  public prompter: Prompter;
+
   public constructor(outputEnabled: boolean) {
     super(outputEnabled);
+    this.spinner = new Spinner(outputEnabled);
+    this.prompter = new Prompter();
   }
 
   public table<T extends Ux.Table.Data>(data: T[], columns: Ux.Table.Columns<T>, options?: Ux.Table.Options): void {


### PR DESCRIPTION
- Exports `Ux` class
- Moves `spinner` and `prompter` instances to `Ux`
- Adds `configAggregator` property to SfCommand
  - Defaults to `ConfigAggregator` unless `this.config.bin === 'sfdx'`, in which case it's a `SfdxConfigAggregator`

[skip-validate-pr]