### PR TITLE
fix: add `summary` field to org flags

### DIFF
--- a/messages/messages.md
+++ b/messages/messages.md
@@ -34,6 +34,14 @@ No default dev hub found. Use -v or --target-dev-hub to specify an environment.
 
 The specified org %s is not a Dev Hub.
 
+# flags.targetOrg.description
+
+Username or alias of the target org
+
+# flags.targetDevHubOrg.description
+
+Username or alias of the Dev Hub org
+
 # flags.apiVersion.description
 
 Override the api version used for api requests made by this command

--- a/messages/messages.md
+++ b/messages/messages.md
@@ -34,13 +34,13 @@ No default dev hub found. Use -v or --target-dev-hub to specify an environment.
 
 The specified org %s is not a Dev Hub.
 
-# flags.targetOrg.description
+# flags.targetOrg.summary
 
-Username or alias of the target org
+Username or alias of the target org.
 
-# flags.targetDevHubOrg.description
+# flags.targetDevHubOrg.summary
 
-Username or alias of the Dev Hub org
+Username or alias of the Dev Hub org.
 
 # flags.apiVersion.description
 

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -73,7 +73,7 @@ export const requiredOrgFlagWithDeprecations = requiredOrgFlag({
  * @deprecated
  */
 export const requiredHubFlagWithDeprecations = requiredHubFlag({
-  aliases: ['targetdevhubusername', 'v'],
+  aliases: ['targetdevhubusername'],
   deprecateAliases: true,
   description: messages.getMessage('flags.targetDevHubOrg.description'),
 });

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -58,7 +58,6 @@ const deprecatedOrgAliases = {
  */
 export const optionalOrgFlagWithDeprecations = optionalOrgFlag({
   ...deprecatedOrgAliases,
-  description: messages.getMessage('flags.targetOrg.description'),
 });
 
 /**
@@ -66,7 +65,6 @@ export const optionalOrgFlagWithDeprecations = optionalOrgFlag({
  */
 export const requiredOrgFlagWithDeprecations = requiredOrgFlag({
   ...deprecatedOrgAliases,
-  description: messages.getMessage('flags.targetOrg.description'),
 });
 
 /**
@@ -75,5 +73,4 @@ export const requiredOrgFlagWithDeprecations = requiredOrgFlag({
 export const requiredHubFlagWithDeprecations = requiredHubFlag({
   aliases: ['targetdevhubusername'],
   deprecateAliases: true,
-  description: messages.getMessage('flags.targetDevHubOrg.description'),
 });

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -58,6 +58,7 @@ const deprecatedOrgAliases = {
  */
 export const optionalOrgFlagWithDeprecations = optionalOrgFlag({
   ...deprecatedOrgAliases,
+  description: messages.getMessage('flags.targetOrg.description'),
 });
 
 /**
@@ -65,6 +66,7 @@ export const optionalOrgFlagWithDeprecations = optionalOrgFlag({
  */
 export const requiredOrgFlagWithDeprecations = requiredOrgFlag({
   ...deprecatedOrgAliases,
+  description: messages.getMessage('flags.targetOrg.description'),
 });
 
 /**
@@ -73,4 +75,5 @@ export const requiredOrgFlagWithDeprecations = requiredOrgFlag({
 export const requiredHubFlagWithDeprecations = requiredHubFlag({
   aliases: ['targetdevhubusername', 'v'],
   deprecateAliases: true,
+  description: messages.getMessage('flags.targetDevHubOrg.description'),
 });

--- a/src/flags/orgFlags.ts
+++ b/src/flags/orgFlags.ts
@@ -97,6 +97,7 @@ export const optionalOrgFlag = Flags.custom({
  */
 export const requiredOrgFlag = Flags.custom({
   char: 'o',
+  summary: messages.getMessage('flags.targetOrg.summary'),
   parse: async (input: string | undefined) => getOrgOrThrow(input),
   default: async () => getOrgOrThrow(),
   defaultHelp: async () => (await getOrgOrThrow())?.getUsername(),
@@ -126,6 +127,7 @@ export const requiredOrgFlag = Flags.custom({
  */
 export const requiredHubFlag = Flags.custom({
   char: 'v',
+  summary: messages.getMessage('flags.targetDevHubOrg.summary'),
   parse: async (input: string | undefined) => getHubOrThrow(input),
   default: async () => getHubOrThrow(),
   defaultHelp: async () => (await getHubOrThrow())?.getUsername(),


### PR DESCRIPTION
This PR adds flag descriptions to all the sfdx org flags. Consumers can't set properties so the flags always showed up without a desc in the help text.


top: latest sf-plugins-core using `requiredOrgFlagWithDeprecations` flag
bottom: `requiredOrgFlagWithDeprecations` with desc
![Screen Shot 2022-11-17 at 14 59 20](https://user-images.githubusercontent.com/6853656/202522837-a356b77a-6785-4123-b772-d94e5c009b5d.png)

[skip-validate-pr]