### PR TITLE
refactor: move confirm to Prompter so it can be on Ux export

### DIFF
--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -336,17 +336,7 @@ export abstract class SfCommand<T> extends Command {
    * @return true if the user confirms, false if they do not.
    */
   public async confirm(message: string, ms = 10000): Promise<boolean> {
-    const { confirmed } = await this.timedPrompt<{ confirmed: boolean }>(
-      [
-        {
-          name: 'confirmed',
-          message,
-          type: 'confirm',
-        },
-      ],
-      ms
-    );
-    return confirmed;
+    return this.prompter.confirm(message, ms);
   }
 
   /**

--- a/src/ux/prompter.ts
+++ b/src/ux/prompter.ts
@@ -49,6 +49,27 @@ export class Prompter {
       return result as T;
     });
   }
+
+  /**
+   * Simplified prompt for single-question confirmation. Times out and throws after 10s
+   *
+   * @param message text to display.  Do not include a question mark.
+   * @param ms milliseconds to wait for user input.  Defaults to 10s.
+   * @return true if the user confirms, false if they do not.
+   */
+  public async confirm(message: string, ms = 10000): Promise<boolean> {
+    const { confirmed } = await this.timedPrompt<{ confirmed: boolean }>(
+      [
+        {
+          name: 'confirmed',
+          message,
+          type: 'confirm',
+        },
+      ],
+      ms
+    );
+    return confirmed;
+  }
 }
 
 export namespace Prompter {


### PR DESCRIPTION
prompt for Confirm lives on sfCommand, but probably belongs on the Prompter class.

This has the advantage of exporting with Ux, so things like plugin-auth's shared prompts can accept a Ux command (similar to how they currently accept the SfdxCommand.UX).  see https://github.com/salesforcecli/plugin-auth/blob/main/src/prompts.ts 