### PR TITLE
fix: update loglevel warn msg to mention env var

### DIFF
--- a/messages/messages.md
+++ b/messages/messages.md
@@ -77,6 +77,7 @@ Warning:
 # warning.loglevel
 
 The loglevel flag is no longer in use on this command. You may use it without error, but it will be ignored.
+Set the log level using the `SFDX_LOG_LEVEL` environment variable.
 
 # actions.tryThis
 


### PR DESCRIPTION
### What does this PR do?
Updates `--loglevel` warn msg to mention `SFDX_LOG_LEVEL` env var as an alternative to set the log level for all loggers.
sfdx-core: https://github.com/forcedotcom/sfdx-core/blob/02e51c10d113f80385c82996595b4e77a9710d6b/src/logger.ts#L518

env var docs: https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_env_variables.htm

logging section - plugin dev guide:
https://github.com/salesforcecli/cli/wiki/Code-Your-Plug-In#logging-levels

### What issues does this PR fix or reference?
[skip-validate-pr]