### PR TITLE
Sm/default-option-for-confirm

### DIFF
--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -336,17 +336,7 @@ export abstract class SfCommand<T> extends Command {
    * @return true if the user confirms, false if they do not.
    */
   public async confirm(message: string, ms = 10000): Promise<boolean> {
-    const { confirmed } = await this.timedPrompt<{ confirmed: boolean }>(
-      [
-        {
-          name: 'confirmed',
-          message,
-          type: 'confirm',
-        },
-      ],
-      ms
-    );
-    return confirmed;
+    return this.prompter.confirm(message, ms);
   }
 
   /**

--- a/src/ux/prompter.ts
+++ b/src/ux/prompter.ts
@@ -49,6 +49,29 @@ export class Prompter {
       return result as T;
     });
   }
+
+  /**
+   * Simplified prompt for single-question confirmation. Times out and throws after 10s
+   *
+   * @param message text to display.  Do not include a question mark.
+   * @param ms milliseconds to wait for user input.  Defaults to 10s.
+   * @param defaultAnswer default answer for the prompt.  Defaults to true.  Pass in `false` to require a positive response.
+   * @return true if the user confirms, false if they do not.
+   */
+  public async confirm(message: string, ms = 10000, defaultAnswer = true): Promise<boolean> {
+    const { confirmed } = await this.timedPrompt<{ confirmed: boolean }>(
+      [
+        {
+          name: 'confirmed',
+          message,
+          type: 'confirm',
+          default: defaultAnswer,
+        },
+      ],
+      ms
+    );
+    return confirmed;
+  }
 }
 
 export namespace Prompter {

--- a/src/ux/prompter.ts
+++ b/src/ux/prompter.ts
@@ -49,6 +49,27 @@ export class Prompter {
       return result as T;
     });
   }
+
+  /**
+   * Simplified prompt for single-question confirmation. Times out and throws after 10s
+   *
+   * @param message text to display.  Do not include a question mark.
+   * @param ms milliseconds to wait for user input.  Defaults to 10s.
+   * @return true if the user confirms, false if they do not.
+   */
+  public async confirm(message: string, ms = 10000): Promise<boolean> {
+    const { confirmed } = await this.timedPrompt<{ confirmed: boolean }>(
+      [
+        {
+          name: 'confirmed',
+          message,
+          type: 'confirm',
+        },
+      ],
+      ms
+    );
+    return confirmed;
+  }
 }
 
 export namespace Prompter {

--- a/src/ux/prompter.ts
+++ b/src/ux/prompter.ts
@@ -55,15 +55,17 @@ export class Prompter {
    *
    * @param message text to display.  Do not include a question mark.
    * @param ms milliseconds to wait for user input.  Defaults to 10s.
+   * @param defaultAnswer default answer for the prompt.  Defaults to true.  Pass in `false` to require a positive response.
    * @return true if the user confirms, false if they do not.
    */
-  public async confirm(message: string, ms = 10000): Promise<boolean> {
+  public async confirm(message: string, ms = 10000, defaultAnswer = true): Promise<boolean> {
     const { confirmed } = await this.timedPrompt<{ confirmed: boolean }>(
       [
         {
           name: 'confirmed',
           message,
           type: 'confirm',
+          default: defaultAnswer,
         },
       ],
       ms


### PR DESCRIPTION
in some cases, you want a confirmation prompt to require a positive answer.  This lets you call `.confirm` with false as the default answer

? This plugin is not digitally signed and its authenticity cannot be verified. Continue installation? (y/N)
? This plugin is not digitally signed and its authenticity cannot be verified. Continue installation? (Y/n)

@W-12084477@