### PR TITLE
fix: required flags use `required` for oclif types

### DIFF
--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -66,6 +66,7 @@ export const optionalOrgFlagWithDeprecations = optionalOrgFlag({
  */
 export const requiredOrgFlagWithDeprecations = requiredOrgFlag({
   ...deprecatedOrgAliases,
+  required: true,
 });
 
 /**
@@ -74,6 +75,7 @@ export const requiredOrgFlagWithDeprecations = requiredOrgFlag({
 export const requiredHubFlagWithDeprecations = requiredHubFlag({
   aliases: ['targetdevhubusername'],
   deprecateAliases: true,
+  required: true,
 });
 
 /**

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -78,7 +78,9 @@ export const requiredHubFlagWithDeprecations = requiredHubFlag({
 });
 
 export type ArrayWithDeprecationOptions = {
+  // prevent invalid options from being passed
   multiple?: true;
+  // parse is disallowed because we have to overwrite it
   parse?: undefined;
 };
 /**

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -7,7 +7,6 @@
 
 import { Flags } from '@oclif/core';
 import { Lifecycle, Messages } from '@salesforce/core';
-import { OptionFlagProps } from '@oclif/core/lib/interfaces';
 import { orgApiVersionFlag } from './flags/orgApiVersion';
 import { optionalOrgFlag, requiredHubFlag, requiredOrgFlag } from './flags/orgFlags';
 
@@ -78,20 +77,20 @@ export const requiredHubFlagWithDeprecations = requiredHubFlag({
   required: true,
 });
 
+export type ArrayWithDeprecationOptions = {
+  multiple?: true;
+  parse?: undefined;
+};
 /**
  * @deprecated
  */
-export const arrayWithDeprecation = (options: Partial<Omit<OptionFlagProps, 'multiple' | 'parse'>>) =>
-  Flags.string({
-    // populate passed options
-    ...options,
-    // overlay those options we own
-    multiple: true,
-    parse: async (input: string) => {
-      const inputParts = input.split(',').map((i) => i.trim());
-      if (inputParts.length > 1) {
-        await Lifecycle.getInstance().emitWarning(messages.getMessage('warning.arrayInputFormat'));
-      }
-      return inputParts;
-    },
-  });
+export const arrayWithDeprecation = Flags.custom<string[], ArrayWithDeprecationOptions>({
+  multiple: true,
+  parse: async (input: string) => {
+    const inputParts = input.split(',').map((i) => i.trim());
+    if (inputParts.length > 1) {
+      await Lifecycle.getInstance().emitWarning(messages.getMessage('warning.arrayInputFormat'));
+    }
+    return inputParts;
+  },
+});

--- a/src/flags/orgFlags.ts
+++ b/src/flags/orgFlags.ts
@@ -101,6 +101,7 @@ export const requiredOrgFlag = Flags.custom({
   parse: async (input: string | undefined) => getOrgOrThrow(input),
   default: async () => getOrgOrThrow(),
   defaultHelp: async () => (await getOrgOrThrow())?.getUsername(),
+  required: true,
 });
 
 /**
@@ -131,4 +132,5 @@ export const requiredHubFlag = Flags.custom({
   parse: async (input: string | undefined) => getHubOrThrow(input),
   default: async () => getHubOrThrow(),
   defaultHelp: async () => (await getHubOrThrow())?.getUsername(),
+  required: true,
 });


### PR DESCRIPTION
for commands that use the required org/hub flag (or the ones from Compatibility) 
those are now marked as with the oclif `required` property 
so that their types appear correctly

before: Org | undefined
after: Org