### PR TITLE
Sm/optional hub

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2022, Salesforce.com, Inc.
+Copyright (c) 2023, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -8,7 +8,7 @@
 import { Flags } from '@oclif/core';
 import { Lifecycle, Messages } from '@salesforce/core';
 import { orgApiVersionFlag } from './flags/orgApiVersion';
-import { optionalOrgFlag, requiredHubFlag, requiredOrgFlag } from './flags/orgFlags';
+import { optionalHubFlag, optionalOrgFlag, requiredHubFlag, requiredOrgFlag } from './flags/orgFlags';
 
 /**
  * Adds an alias for the deprecated sfdx-style "apiversion" and provides a warning if it is used
@@ -75,6 +75,15 @@ export const requiredHubFlagWithDeprecations = requiredHubFlag({
   aliases: ['targetdevhubusername'],
   deprecateAliases: true,
   required: true,
+});
+
+/**
+ * @deprecated
+ */
+export const optionalHubFlagWithDeprecations = optionalHubFlag({
+  aliases: ['targetdevhubusername'],
+  deprecateAliases: true,
+  required: false,
 });
 
 export type ArrayWithDeprecationOptions = {

--- a/src/exported.ts
+++ b/src/exported.ts
@@ -16,7 +16,7 @@ export * from './types';
 export { SfCommand, SfCommandInterface, StandardColors } from './sfCommand';
 export * from './compatibility';
 // custom flags
-import { requiredOrgFlag, requiredHubFlag, optionalOrgFlag } from './flags/orgFlags';
+import { requiredOrgFlag, requiredHubFlag, optionalOrgFlag, optionalHubFlag } from './flags/orgFlags';
 import { salesforceIdFlag } from './flags/salesforceId';
 import { orgApiVersionFlag } from './flags/orgApiVersion';
 import { durationFlag } from './flags/duration';
@@ -35,4 +35,5 @@ export const Flags = {
   requiredOrg: requiredOrgFlag,
   requiredHub: requiredHubFlag,
   optionalOrg: optionalOrgFlag,
+  optionalHub: optionalHubFlag,
 };

--- a/src/flags/orgFlags.ts
+++ b/src/flags/orgFlags.ts
@@ -10,10 +10,10 @@ import { Messages, Org, ConfigAggregator, OrgConfigProperties } from '@salesforc
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
 
-async function maybeGetOrg(input: string): Promise<Org>;
-async function maybeGetOrg(input: undefined): Promise<undefined>;
-async function maybeGetOrg(input?: string | undefined): Promise<Org | undefined>;
-async function maybeGetOrg(input?: string | undefined): Promise<Org | undefined> {
+export async function maybeGetOrg(input: string): Promise<Org>;
+export async function maybeGetOrg(input: undefined): Promise<undefined>;
+export async function maybeGetOrg(input?: string | undefined): Promise<Org | undefined>;
+export async function maybeGetOrg(input?: string | undefined): Promise<Org | undefined> {
   try {
     return await Org.create({ aliasOrUsername: input });
   } catch (e) {
@@ -25,7 +25,7 @@ async function maybeGetOrg(input?: string | undefined): Promise<Org | undefined>
   }
 }
 
-const maybeGetHub = async (input?: string): Promise<Org | undefined> => {
+export const maybeGetHub = async (input?: string): Promise<Org | undefined> => {
   const org = await maybeGetOrg(input ?? (await getDefaultHub(false)));
   if (org) {
     return ensureDevHub(org, input ?? org.getUsername());
@@ -34,7 +34,7 @@ const maybeGetHub = async (input?: string): Promise<Org | undefined> => {
   }
 };
 
-const getOrgOrThrow = async (input?: string): Promise<Org> => {
+export const getOrgOrThrow = async (input?: string): Promise<Org> => {
   const org = await maybeGetOrg(input);
   if (!org) {
     throw messages.createError('errors.NoDefaultEnv');
@@ -61,9 +61,9 @@ async function getDefaultHub(throwIfNotFound: boolean): Promise<string | undefin
   return aliasOrUsername;
 }
 
-const getHubOrThrow = async (aliasOrUsername?: string): Promise<Org> => {
+export const getHubOrThrow = async (aliasOrUsername?: string): Promise<Org> => {
   const resolved = aliasOrUsername ?? (await getDefaultHub(true));
-  const org = await Org.create({ aliasOrUsername: resolved });
+  const org = await Org.create({ aliasOrUsername: resolved, isDevHub: true });
   return ensureDevHub(org, resolved);
 };
 

--- a/src/flags/orgFlags.ts
+++ b/src/flags/orgFlags.ts
@@ -10,7 +10,10 @@ import { Messages, Org, ConfigAggregator, OrgConfigProperties } from '@salesforc
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sf-plugins-core', 'messages');
 
-const maybeGetOrg = async (input?: string): Promise<Org | undefined> => {
+async function maybeGetOrg(input: string): Promise<Org>;
+async function maybeGetOrg(input: undefined): Promise<undefined>;
+async function maybeGetOrg(input?: string | undefined): Promise<Org | undefined>;
+async function maybeGetOrg(input?: string | undefined): Promise<Org | undefined> {
   try {
     return await Org.create({ aliasOrUsername: input });
   } catch (e) {
@@ -19,6 +22,15 @@ const maybeGetOrg = async (input?: string): Promise<Org | undefined> => {
     } else {
       throw e;
     }
+  }
+}
+
+const maybeGetHub = async (input?: string): Promise<Org | undefined> => {
+  const org = await maybeGetOrg(input ?? (await getDefaultHub(false)));
+  if (org) {
+    return ensureDevHub(org, input ?? org.getUsername());
+  } else {
+    return undefined;
   }
 };
 
@@ -30,20 +42,29 @@ const getOrgOrThrow = async (input?: string): Promise<Org> => {
   return org;
 };
 
-const getHubOrThrow = async (aliasOrUsername?: string): Promise<Org> => {
-  if (!aliasOrUsername) {
-    // check config for a default
-    const config = await ConfigAggregator.create();
-    aliasOrUsername = config.getInfo(OrgConfigProperties.TARGET_DEV_HUB)?.value as string;
-    if (!aliasOrUsername) {
-      throw messages.createError('errors.NoDefaultDevHub');
-    }
-  }
-  const org = await Org.create({ aliasOrUsername });
+const ensureDevHub = async (org: Org, aliasOrUsername?: string): Promise<Org> => {
   if (await org.determineIfDevHubOrg()) {
     return org;
   }
-  throw messages.createError('errors.NotADevHub', [aliasOrUsername]);
+  throw messages.createError('errors.NotADevHub', [aliasOrUsername ?? org.getUsername()]);
+};
+
+async function getDefaultHub(throwIfNotFound: false): Promise<string | undefined>;
+async function getDefaultHub(throwIfNotFound: true): Promise<string>;
+async function getDefaultHub(throwIfNotFound: boolean): Promise<string | undefined> {
+  // check config for a default
+  const config = await ConfigAggregator.create();
+  const aliasOrUsername = config.getInfo(OrgConfigProperties.TARGET_DEV_HUB)?.value as string;
+  if (throwIfNotFound && !aliasOrUsername) {
+    throw messages.createError('errors.NoDefaultDevHub');
+  }
+  return aliasOrUsername;
+}
+
+const getHubOrThrow = async (aliasOrUsername?: string): Promise<Org> => {
+  const resolved = aliasOrUsername ?? (await getDefaultHub(true));
+  const org = await Org.create({ aliasOrUsername: resolved });
+  return ensureDevHub(org, resolved);
 };
 
 /**
@@ -133,4 +154,34 @@ export const requiredHubFlag = Flags.custom({
   default: async () => getHubOrThrow(),
   defaultHelp: async () => (await getHubOrThrow())?.getUsername(),
   required: true,
+});
+
+/**
+ * An optional org that, if present, must be a devHub
+ * Will throw if the specified org does not exist
+ * Will default to the default dev hub if one is not specified
+ * Will NOT throw if no default deb hub exists and none is specified
+ *
+ * @example
+ *
+ * ```
+ * import { Flags } from '@salesforce/sf-plugins-core';
+ * public static flags = {
+ *     // setting length or prefix
+ *    'target-org': optionalHubFlag(),
+ *    // adding properties
+ *    'flag2': optionalHubFlag({
+ *        description: 'flag2 description',
+ *        char: 'h'
+ *     }),
+ * }
+ * ```
+ */
+export const optionalHubFlag = Flags.custom({
+  char: 'v',
+  summary: messages.getMessage('flags.targetDevHubOrg.summary'),
+  parse: async (input: string | undefined) => maybeGetHub(input),
+  default: async () => maybeGetHub(),
+  defaultHelp: async () => (await maybeGetHub())?.getUsername(),
+  required: false,
 });

--- a/test/unit/flags/orgFlags.test.ts
+++ b/test/unit/flags/orgFlags.test.ts
@@ -7,13 +7,7 @@
 import { Org, SfError, OrgConfigProperties } from '@salesforce/core';
 import { MockTestOrgData, shouldThrow, TestContext } from '@salesforce/core/lib/testSetup';
 import { assert, expect, config } from 'chai';
-import {
-  getHubOrThrow,
-  getOrgOrThrow,
-  maybeGetHub,
-  maybeGetOrg,
-  // maybeGetHub, maybeGetOrg, getHubOrThrow
-} from '../../../src/flags/orgFlags';
+import { getHubOrThrow, getOrgOrThrow, maybeGetHub, maybeGetOrg } from '../../../src/flags/orgFlags';
 
 config.truncateThreshold = 0;
 
@@ -37,6 +31,7 @@ describe('org flags', () => {
       const retrieved = await getOrgOrThrow(testOrg.username);
       expect(retrieved.getOrgId()).to.equal(testOrg.orgId);
     });
+    // skipped tests are waiting for a fix to core/testSetup https://github.com/forcedotcom/sfdx-core/pull/748
     it.skip('has input, no org found => throw', async () => {
       try {
         await shouldThrow(getOrgOrThrow('nope@bad.fail'));
@@ -64,7 +59,6 @@ describe('org flags', () => {
       const retrieved = await maybeGetOrg(testOrg.username);
       expect(retrieved.getOrgId()).to.equal(testOrg.orgId);
     });
-    // skipped tests are waiting for a fix to core/testSetup https://github.com/forcedotcom/sfdx-core/pull/748
     it.skip('has input, no org => throw', async () => {
       try {
         await shouldThrow(maybeGetOrg('nope@bad.fail'));
@@ -93,7 +87,6 @@ describe('org flags', () => {
         expect(e).to.have.property('name', 'NotADevHubError');
       }
     });
-    // skipped tests are waiting for a fix to core/testSetup https://github.com/forcedotcom/sfdx-core/pull/748
     it.skip('has input, no org => throw', async () => {
       try {
         await shouldThrow(maybeGetHub('nope@bad.fail'));

--- a/test/unit/flags/orgFlags.test.ts
+++ b/test/unit/flags/orgFlags.test.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { Org, SfError, OrgConfigProperties } from '@salesforce/core';
+import { MockTestOrgData, shouldThrow, TestContext } from '@salesforce/core/lib/testSetup';
+import { assert, expect, config } from 'chai';
+import {
+  getHubOrThrow,
+  getOrgOrThrow,
+  maybeGetHub,
+  maybeGetOrg,
+  // maybeGetHub, maybeGetOrg, getHubOrThrow
+} from '../../../src/flags/orgFlags';
+
+config.truncateThreshold = 0;
+
+describe('org flags', () => {
+  const $$ = new TestContext();
+  const testOrg = new MockTestOrgData();
+  const testHub = new MockTestOrgData();
+  // set these into the "cache" to avoid "server checks"
+  testOrg.isDevHub = false;
+  testHub.isDevHub = true;
+
+  beforeEach(async () => {
+    await $$.stubAuths(testOrg, testHub);
+  });
+  afterEach(async () => {
+    $$.restore();
+  });
+
+  describe('requiredOrg', () => {
+    it('has input, returns org', async () => {
+      const retrieved = await getOrgOrThrow(testOrg.username);
+      expect(retrieved.getOrgId()).to.equal(testOrg.orgId);
+    });
+    it.skip('has input, no org found => throw', async () => {
+      try {
+        await shouldThrow(getOrgOrThrow('nope@bad.fail'));
+      } catch (e) {
+        assert(e instanceof SfError);
+        expect(e).to.have.property('name', 'NamedOrgNotFound');
+      }
+    });
+    it('no input, uses default', async () => {
+      await $$.stubConfig({ [OrgConfigProperties.TARGET_ORG]: testOrg.username });
+      expect(await getOrgOrThrow()).to.be.instanceOf(Org);
+    });
+    it('no input, no default => throw', async () => {
+      await $$.stubConfig({});
+      try {
+        await shouldThrow(getOrgOrThrow());
+      } catch (e) {
+        assert(e instanceof SfError);
+        expect(e).to.have.property('name', 'NoDefaultEnvError');
+      }
+    });
+  });
+  describe('optionalOrg', () => {
+    it('has input, returns org', async () => {
+      const retrieved = await maybeGetOrg(testOrg.username);
+      expect(retrieved.getOrgId()).to.equal(testOrg.orgId);
+    });
+    // skipped tests are waiting for a fix to core/testSetup https://github.com/forcedotcom/sfdx-core/pull/748
+    it.skip('has input, no org => throw', async () => {
+      try {
+        await shouldThrow(maybeGetOrg('nope@bad.fail'));
+      } catch (e) {
+        assert(e instanceof SfError);
+        expect(e).to.have.property('name', 'NamedOrgNotFound');
+      }
+    });
+    it('no input, uses default', async () => {
+      await $$.stubConfig({ [OrgConfigProperties.TARGET_ORG]: testOrg.username });
+      expect(await maybeGetOrg()).to.be.instanceOf(Org);
+    });
+    it('no input, no default => ok', async () => {
+      expect(await maybeGetOrg()).to.be.undefined;
+    });
+  });
+  describe('requiredHub', () => {
+    it('has input, returns org', async () => {
+      expect(await getHubOrThrow(testHub.username)).to.be.instanceOf(Org);
+    });
+    it('has input, finds org that is not a hub => throw', async () => {
+      try {
+        await shouldThrow(getHubOrThrow(testOrg.username));
+      } catch (e) {
+        assert(e instanceof SfError);
+        expect(e).to.have.property('name', 'NotADevHubError');
+      }
+    });
+    // skipped tests are waiting for a fix to core/testSetup https://github.com/forcedotcom/sfdx-core/pull/748
+    it.skip('has input, no org => throw', async () => {
+      try {
+        await shouldThrow(maybeGetHub('nope@bad.fail'));
+      } catch (e) {
+        assert(e instanceof SfError);
+        expect(e).to.have.property('name', 'NamedOrgNotFound');
+      }
+    });
+    it('no input, uses default', async () => {
+      await $$.stubConfig({ [OrgConfigProperties.TARGET_DEV_HUB]: testHub.username });
+      const retrieved = await getHubOrThrow();
+      expect(retrieved).to.be.instanceOf(Org);
+      expect(retrieved.getOrgId()).to.equal(testHub.orgId);
+    });
+    it('no input, uses default but is not a hub => throw', async () => {
+      await $$.stubConfig({ [OrgConfigProperties.TARGET_DEV_HUB]: testOrg.username });
+      try {
+        await shouldThrow(getHubOrThrow());
+      } catch (e) {
+        assert(e instanceof SfError);
+        expect(e).to.have.property('name', 'NotADevHubError');
+      }
+    });
+    it('no input, no default => throws', async () => {
+      await $$.stubConfig({});
+      try {
+        await shouldThrow(getHubOrThrow());
+      } catch (e) {
+        assert(e instanceof SfError);
+        expect(e).to.have.property('name', 'NoDefaultDevHubError');
+      }
+    });
+  });
+  describe('optionalHub', () => {
+    it('has input, returns org', async () => {
+      const retrieved = await maybeGetHub(testHub.username);
+      expect(retrieved).to.be.instanceOf(Org);
+    });
+    it('has input, finds org that is not a hub => throw', async () => {
+      try {
+        await shouldThrow(maybeGetHub(testOrg.username));
+      } catch (e) {
+        assert(e instanceof SfError);
+        expect(e).to.have.property('name', 'NotADevHubError');
+      }
+    });
+    it.skip('has input, no org => throws', async () => {
+      try {
+        await shouldThrow(maybeGetHub('nope@bad.fail'));
+      } catch (e) {
+        assert(e instanceof SfError);
+        expect(e).to.have.property('name', 'NamedOrgNotFound');
+      }
+    });
+    it('no input, uses default', async () => {
+      await $$.stubConfig({ [OrgConfigProperties.TARGET_DEV_HUB]: testHub.username });
+      const retrieved = await maybeGetHub();
+      expect(retrieved).to.be.instanceOf(Org);
+      expect(retrieved.getOrgId()).to.equal(testHub.orgId);
+    });
+    it('no input, uses default but is not a hub => throw', async () => {
+      await $$.stubConfig({ [OrgConfigProperties.TARGET_DEV_HUB]: testOrg.username });
+      try {
+        await shouldThrow(maybeGetHub());
+      } catch (e) {
+        assert(e instanceof SfError);
+        expect(e).to.have.property('name', 'NotADevHubError');
+      }
+    });
+    it('no input, no default => ok', async () => {
+      await $$.stubConfig({});
+      expect(await maybeGetHub()).to.be.undefined;
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,25 +752,25 @@
   integrity sha512-BJ25uphssN42Zy6kksheFHMTLiR98AAHe/Wxnv0T4dYxtrEbUjSXVAGKZqfewJPFXA4xB5gxC+rQZtfz6xKCFg==
 
 "@salesforce/ts-sinon@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/ts-sinon/-/ts-sinon-1.4.2.tgz#7b76f80c104c891334b84ad664ab048fd1fbb1ff"
-  integrity sha512-yoNaHdw+5IYUs8Jg/c30AuPG5jhWGR/zdy0G2XmLSzVhf/8duNTbnSl3AWYplCvU/Cz3CFIs1XnjePG0Resxmw==
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/ts-sinon/-/ts-sinon-1.4.4.tgz#ee7039f7eb6c488d58b0a3365e7196e9b1b1ebb4"
+  integrity sha512-27kF+8flAEGGikIrLrGkDiFUCgukhRf2cRhYBbD0ihG8RedsYoFTsEW9gG9VApVgWACyhkEmGICisJl8LRD7Rg==
   dependencies:
-    "@salesforce/ts-types" "^1.7.1"
+    "@salesforce/ts-types" "^1.7.2"
     sinon "^5.1.1"
     tslib "^2.2.0"
 
-"@salesforce/ts-types@^1.5.21", "@salesforce/ts-types@^1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-1.7.1.tgz#86b0d0c3bfd5c9b1752662a019a3d2f3bc8ff118"
-  integrity sha512-jwZb8fYxbOmEckoJTxG2+5ZEJNJOFxmRJ/FioPnSu4IMFzpK3QbyujfqpHwLfPKHq0xlKRMx+F8QAVVKI/PA4w==
+"@salesforce/ts-types@^1.5.21", "@salesforce/ts-types@^1.7.1", "@salesforce/ts-types@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-1.7.2.tgz#ab40399d291c7eca57efc9890daf2fa2632197ec"
+  integrity sha512-eCpWKEb03UCKBJ6Svp0Vwcwt+fG6BQbopO4x5wt6CYeT8Rjt0dbDQicZPmVL59j2qyt3Q4Y4EYsxXUGZmdfvDw==
   dependencies:
     tslib "^2.4.1"
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1", "@sinonjs/commons@^1.8.3":
-  version "1.8.3"
-  resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
-  integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.6.tgz#80c516a4dc264c2a69115e7578d62581ff455ed9"
+  integrity sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==
   dependencies:
     type-detect "4.0.8"
 
@@ -797,14 +797,14 @@
 
 "@sinonjs/formatio@^2.0.0":
   version "2.0.0"
-  resolved "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
   integrity sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==
   dependencies:
     samsam "1.3.0"
 
 "@sinonjs/formatio@^3.2.1":
   version "3.2.2"
-  resolved "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz#771c60dfa75ea7f2d68e3b94c7e888a78781372c"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.2.tgz#771c60dfa75ea7f2d68e3b94c7e888a78781372c"
   integrity sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==
   dependencies:
     "@sinonjs/commons" "^1"
@@ -812,7 +812,7 @@
 
 "@sinonjs/samsam@^3.1.0":
   version "3.3.3"
-  resolved "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
   integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
   dependencies:
     "@sinonjs/commons" "^1.3.0"
@@ -1279,8 +1279,8 @@ array-differ@^3.0.0:
 
 array-from@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
-  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==
 
 array-ify@^1.0.0:
   version "1.0.0"
@@ -2025,7 +2025,7 @@ diff@5.0.0:
 
 diff@^3.5.0:
   version "3.5.0"
-  resolved "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 diff@^4.0.1, diff@^4.0.2:
@@ -3756,12 +3756,12 @@ log-symbols@4.1.0, log-symbols@^4.1.0:
 
 lolex@^2.4.2:
   version "2.7.5"
-  resolved "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
   integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
 
 lolex@^5.0.1:
   version "5.1.2"
-  resolved "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
   integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
@@ -4048,7 +4048,7 @@ nice-try@^1.0.4:
 
 nise@^1.3.3:
   version "1.5.3"
-  resolved "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz#9d2cfe37d44f57317766c6e9408a359c5d3ac1f7"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.3.tgz#9d2cfe37d44f57317766c6e9408a359c5d3ac1f7"
   integrity sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==
   dependencies:
     "@sinonjs/formatio" "^3.2.1"
@@ -4772,7 +4772,7 @@ safe-json-stringify@~1:
 
 samsam@1.3.0:
   version "1.3.0"
-  resolved "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
   integrity sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==
 
 sax@>=0.6.0:
@@ -4920,7 +4920,7 @@ sinon@10.0.1:
 
 sinon@^5.1.1:
   version "5.1.1"
-  resolved "https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz#19c59810ffb733ea6e76a28b94a71fc4c2f523b8"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-5.1.1.tgz#19c59810ffb733ea6e76a28b94a71fc4c2f523b8"
   integrity sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==
   dependencies:
     "@sinonjs/formatio" "^2.0.0"


### PR DESCRIPTION
create an optionalHubFlag (and its deprecated equivalent) to avoid doing this in several sfdx plugins
testCoverage for orgFlags

> there's a bug in testSetup that needs to be fixed for the skipped UT to work properly.  It works fine IRL, just not in testSetup.  https://github.com/forcedotcom/sfdx-core/pull/748

I needed this for [@W-12083557@](https://gus.lightning.force.com/a07EE00001DTPYDYA5) but it also has uses in *at least* plugin-user, maybe more.
