### PR TITLE
Sm/warnings to stderr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,15 @@ jobs:
           - plugin-env
           - plugin-generate
           - plugin-login
+          - plugin-org
+          - plugin-data
+          - plugin-schema
+          - plugin-limits
+          - plugin-signups
+          - plugin-templates
+          - plugin-custom-metadata
+          - plugin-community
+          - plugin-user
         os:
           - ubuntu-latest
           - windows-latest

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -233,7 +233,7 @@ export abstract class SfCommand<T> extends Command {
       ...this.formatActions(typeof input === 'string' ? [] : input.actions ?? [], { actionColor: StandardColors.info })
     );
 
-    this.log(colorizedArgs.join(os.EOL));
+    this.logToStderr(colorizedArgs.join(os.EOL));
     return input;
   }
 

--- a/test/unit/sfCommand.test.ts
+++ b/test/unit/sfCommand.test.ts
@@ -51,32 +51,32 @@ describe('info messages', () => {
 });
 describe('warning messages', () => {
   test
-    .stdout()
+    .stderr()
     .do(() => {
       const testCommand = new TestCommand([], {} as Config);
       testCommand.warn('foo bar baz');
     })
     .it('should show a info message from a string', (ctx) => {
-      expect(ctx.stdout).to.include('Warning: foo bar baz');
+      expect(ctx.stderr).to.include('Warning: foo bar baz');
     });
   test
-    .stdout()
+    .stderr()
     .do(() => {
       const testCommand = new TestCommand([], {} as Config);
       testCommand.warn(new Error('foo bar baz') as SfCommand.Warning);
     })
     .it('should show a warning message from Error, no actions', (ctx) => {
-      expect(ctx.stdout).to.include('Warning: foo bar baz');
+      expect(ctx.stderr).to.include('Warning: foo bar baz');
     });
   test
-    .stdout()
+    .stderr()
     .do(() => {
       const testCommand = new TestCommand([], {} as Config);
       const infoError = new SfError('foo bar baz', 'foo', ['this', 'is an', 'action']) as Error;
       testCommand.warn(infoError as SfCommand.Info);
     })
     .it('should show a info message from Error, with actions', (ctx) => {
-      expect(ctx.stdout).to.include('Warning: foo bar baz');
-      expect(ctx.stdout).to.include(['this', 'is an', 'action'].join(os.EOL));
+      expect(ctx.stderr).to.include('Warning: foo bar baz');
+      expect(ctx.stderr).to.include(['this', 'is an', 'action'].join(os.EOL));
     });
 });


### PR DESCRIPTION
modify this.warn to send messages to stderr instead of stdout.

Why ? 

```sh
 sfdx force:data:soql:query -q "SELECT SOMETHING ..." --result-format csv > somefile.csv
```

this is likely to break a LOT of tests that look for warnings.
[@W-12526553@](https://gus.lightning.force.com/a07EE00001L3lP6YAJ)