### PR TITLE
fix: dont allow hooks to exit process

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "/messages"
   ],
   "dependencies": {
-    "@oclif/core": "^2.0.10",
+    "@oclif/core": "^2.1.1",
     "@salesforce/core": "^3.33.1",
     "@salesforce/kit": "^1.8.3",
     "@salesforce/ts-types": "^1.7.1",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -39,7 +39,7 @@ export class SfHook {
     options: SfHooks[T]['options'] = {}
   ): Promise<Hook.Result<SfHooks[T]['return']>> {
     const timeout = Duration.milliseconds(env.getNumber('SF_HOOK_TIMEOUT_MS') ?? 5000);
-    const results = await config.runHook<T>(hookName, options, timeout.milliseconds);
+    const results = await config.runHook<T>(hookName, options, timeout.milliseconds, true);
     results.failures.forEach((failure) => {
       ux.debug(`Failed to run ${hookName} hook for ${failure.plugin.name}`);
       ux.debug(failure.error.toString());

--- a/yarn.lock
+++ b/yarn.lock
@@ -574,10 +574,10 @@
     widest-line "^3.1.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/core@^2.0.10":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.0.10.tgz#2d5ffd79b05de388934103ff567b8d6d0886a501"
-  integrity sha512-icRaEpQ/dK596Z0rYcGoeMTiXyPv9DbTm8c47NcDXmmOvMuxBr1ntB9/QjsD1fe0BcjZtsfRAbsBT0RgEHwuhg==
+"@oclif/core@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.1.1.tgz#8ffa83fe39f43bd66fb6f0731527b17911fc937e"
+  integrity sha512-t0zez9ydn3eveZM2vsMbrL2hNKzlHSfwEl4A29VlIimOxpQDB9AKZXX02lhTB3BSKbVF24UOlkzYiX7n9Bdc0A==
   dependencies:
     "@types/cli-progress" "^3.11.0"
     ansi-escapes "^4.3.2"
@@ -603,7 +603,7 @@
     strip-ansi "^6.0.1"
     supports-color "^8.1.1"
     supports-hyperlinks "^2.2.0"
-    tslib "^2.4.1"
+    tslib "^2.5.0"
     widest-line "^3.1.0"
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
@@ -5519,6 +5519,11 @@ tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
+tslib@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
Don't allow hooks to exit process

Depends on https://github.com/oclif/core/pull/620

[skip-validate-pr]