### PR TITLE
fix: throw from catch

### DIFF
--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -430,7 +430,7 @@ export abstract class SfCommand<T> extends Command {
     }
   }
 
-  protected async catch(error: Error | SfError | SfCommand.Error): Promise<never> {
+  protected async catch(error: Error | SfError | SfCommand.Error): Promise<SfCommand.Error> {
     // transform an unknown error into one that conforms to the interface
     const codeFromError = error instanceof SfError ? error.exitCode : 1;
     process.exitCode ??= codeFromError;

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -430,7 +430,7 @@ export abstract class SfCommand<T> extends Command {
     }
   }
 
-  protected async catch(error: Error | SfError | SfCommand.Error): Promise<SfCommand.Error> {
+  protected async catch(error: Error | SfError | SfCommand.Error): Promise<never> {
     // transform an unknown error into one that conforms to the interface
     const codeFromError = error instanceof SfError ? error.exitCode : 1;
     process.exitCode ??= codeFromError;
@@ -454,7 +454,8 @@ export abstract class SfCommand<T> extends Command {
     } else {
       this.logToStderr(this.formatError(sfCommandError));
     }
-    return sfCommandError;
+
+    throw sfCommandError;
   }
 
   /**


### PR DESCRIPTION
- Throws error from `catch` so that unit tests can use `shouldThrow`
- Removes `SfError` instance checks in `catch` to prevent testing issues with multiple versions of sfdx-core being used across the dependency tree

[skip-validate-pr]