### PR TITLE
fix: add skipOclifErrorHandling to errors thrown from SfCommand.catch

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "/messages"
   ],
   "dependencies": {
-    "@oclif/core": "^2.2.1",
+    "@oclif/core": "^2.4.0",
     "@salesforce/core": "^3.33.1",
     "@salesforce/kit": "^1.8.3",
     "@salesforce/ts-types": "^1.7.1",

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -477,8 +477,11 @@ export abstract class SfCommand<T> extends Command {
     err.stack = sfCommandError.stack;
     // @ts-expect-error because code is not on SfError
     err.code = codeFromError;
-    // @ts-expect-error because code is not on SfError
+    // @ts-expect-error because status is not on SfError
     err.status = sfCommandError.status;
+
+    // @ts-expect-error because skipOclifErrorHandling is not on SfError
+    err.skipOclifErrorHandling = true;
 
     throw err;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -574,10 +574,10 @@
     widest-line "^3.1.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/core@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.2.1.tgz#fc94d3543ed47ddd5393a719346997f2a250204c"
-  integrity sha512-TxIFfccAwb8SiVADZWxIS/GG2bcw0yBDBBxzqBQl7jurfG0wQtdu6jLfHHdVGYaYyMKw1UVZTFFLtX8iwRTW/Q==
+"@oclif/core@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.4.0.tgz#8e5983dd0d50a3c0c170a844fe8925cb639f0a9f"
+  integrity sha512-wWUnOOfQQty0k1Cstm/iWW6pbG0mHzU7rcUtab2Sni9kjBPCcy6ENTgpsWbb/WdITopqtXmvpYII2fgcjKdzUA==
   dependencies:
     "@types/cli-progress" "^3.11.0"
     ansi-escapes "^4.3.2"
@@ -585,7 +585,7 @@
     cardinal "^2.1.1"
     chalk "^4.1.2"
     clean-stack "^3.0.1"
-    cli-progress "^3.11.2"
+    cli-progress "^3.12.0"
     debug "^4.3.4"
     ejs "^3.1.8"
     fs-extra "^9.1.0"
@@ -1693,7 +1693,7 @@ cli-progress@^3.10.0, cli-progress@^3.4.0:
   dependencies:
     string-width "^4.2.0"
 
-cli-progress@^3.11.2:
+cli-progress@^3.12.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.12.0.tgz#807ee14b66bcc086258e444ad0f19e7d42577942"
   integrity sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==


### PR DESCRIPTION
Tell oclif to skip error handling for errors thrown from `SfCommand.catch`

Depends on https://github.com/oclif/core/pull/642

@W-12615284@