### PR TITLE
fix: support setting json = true via env

### DIFF
--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -215,7 +215,7 @@ export abstract class SfCommand<T> extends Command {
     // unless it's been explicitly disabled on the command's statics
     return (
       super.jsonEnabled() ||
-      (SfCommand.enableJsonFlag !== false &&
+      (this.statics.enableJsonFlag !== false &&
         envVars.getString(EnvironmentVariable.SF_CONTENT_TYPE)?.toUpperCase() === 'JSON')
     );
   }

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -209,6 +209,11 @@ export abstract class SfCommand<T> extends Command {
     return this.constructor as typeof SfCommand;
   }
 
+  public jsonEnabled(): boolean {
+    // can come from either oclif's detection of the flag's presence and truthiness OR from the env
+    // https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_json_support.htm
+    return super.jsonEnabled() || envVars.getString(EnvironmentVariable.SF_CONTENT_TYPE) === 'JSON';
+  }
   /**
    * Log a success message that has the standard success message color applied.
    *

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -210,9 +210,14 @@ export abstract class SfCommand<T> extends Command {
   }
 
   public jsonEnabled(): boolean {
-    // can come from either oclif's detection of the flag's presence and truthiness OR from the env
     // https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_json_support.htm
-    return super.jsonEnabled() || envVars.getString(EnvironmentVariable.SF_CONTENT_TYPE) === 'JSON';
+    // can come from either oclif's detection of the flag's presence and truthiness OR from the env
+    // unless it's been explicitly disabled on the command's statics
+    return (
+      super.jsonEnabled() ||
+      (SfCommand.enableJsonFlag !== false &&
+        envVars.getString(EnvironmentVariable.SF_CONTENT_TYPE)?.toUpperCase() === 'JSON')
+    );
   }
   /**
    * Log a success message that has the standard success message color applied.

--- a/test/unit/sfCommand.test.ts
+++ b/test/unit/sfCommand.test.ts
@@ -43,6 +43,12 @@ class TestCommand extends SfCommand<void> {
   }
 }
 
+class NonJsonCommand extends SfCommand<void> {
+  public static enableJsonFlag = false;
+  public async run(): Promise<void> {
+    await this.parse(TestCommand);
+  }
+}
 describe('jsonEnabled', () => {
   beforeEach(() => {
     delete process.env.SF_CONTENT_TYPE;
@@ -82,6 +88,20 @@ describe('jsonEnabled', () => {
     // @ts-expect-error not really an oclif config
     const cmd = new TestCommand(['--json'], oclifConfig);
     expect(cmd.jsonEnabled()).to.be.true;
+  });
+
+  describe('non json command', () => {
+    it('non-json command base case', () => {
+      // @ts-expect-error not really an oclif config
+      const cmd = new NonJsonCommand([], oclifConfig);
+      expect(cmd.jsonEnabled()).to.be.false;
+    });
+    it('non-json command is not affected by env', () => {
+      process.env.SF_CONTENT_TYPE = 'JSON';
+      // @ts-expect-error not really an oclif config
+      const cmd = new NonJsonCommand([], oclifConfig);
+      expect(cmd.jsonEnabled()).to.be.false;
+    });
   });
 });
 

--- a/test/unit/sfCommand.test.ts
+++ b/test/unit/sfCommand.test.ts
@@ -10,6 +10,7 @@ import { TestContext } from '@salesforce/core/lib/testSetup';
 import { stubMethod } from '@salesforce/ts-sinon';
 import { expect } from 'chai';
 import { SfError } from '@salesforce/core';
+import { Config } from '@oclif/core/lib/interfaces';
 import { SfCommand } from '../../src/sfCommand';
 
 class TestCommand extends SfCommand<void> {
@@ -41,6 +42,48 @@ class TestCommand extends SfCommand<void> {
     }
   }
 }
+
+describe('jsonEnabled', () => {
+  beforeEach(() => {
+    delete process.env.SF_CONTENT_TYPE;
+  });
+
+  const oclifConfig = {} as unknown as Config;
+  it('not json', () => {
+    // @ts-expect-error not really an oclif config
+    const cmd = new TestCommand([], oclifConfig);
+    expect(cmd.jsonEnabled()).to.be.false;
+  });
+  it('json via flag but not env', () => {
+    // @ts-expect-error not really an oclif config
+    const cmd = new TestCommand(['--json'], oclifConfig);
+    expect(cmd.jsonEnabled()).to.be.true;
+  });
+  it('json via env but not flag', () => {
+    process.env.SF_CONTENT_TYPE = 'JSON';
+    // @ts-expect-error not really an oclif config
+    const cmd = new TestCommand([], oclifConfig);
+    expect(cmd.jsonEnabled()).to.be.true;
+  });
+  it('json via env lowercase', () => {
+    process.env.SF_CONTENT_TYPE = 'json';
+    // @ts-expect-error not really an oclif config
+    const cmd = new TestCommand([], oclifConfig);
+    expect(cmd.jsonEnabled()).to.be.true;
+  });
+  it('not json via env that is not json', () => {
+    process.env.SF_CONTENT_TYPE = 'foo';
+    // @ts-expect-error not really an oclif config
+    const cmd = new TestCommand([], oclifConfig);
+    expect(cmd.jsonEnabled()).to.be.false;
+  });
+  it('json via both flag and env', () => {
+    process.env.SF_CONTENT_TYPE = 'JSON';
+    // @ts-expect-error not really an oclif config
+    const cmd = new TestCommand(['--json'], oclifConfig);
+    expect(cmd.jsonEnabled()).to.be.true;
+  });
+});
 
 describe('info messages', () => {
   const $$ = new TestContext();


### PR DESCRIPTION
`SFDX_CONTENT_TYPE` makes json in sfdxCommand, but wasn't in SfCommand.

extends oclif/core/command's jsonEnabled() method but adds additional criteria that arrive at `true`

note: this is refers to SF_CONTENT_TYPE but a pending change to sfdx-core translates the env from SFDX and provides a warning.  https://github.com/forcedotcom/sfdx-core/pull/817/files#diff-2a7aeba6131c233030f6f8f21990a6c6b01e15af4eb62714237f8f13b06ca000

@W-13097825@