### PR TITLE
fix: add more error properties to support push errors

### DIFF
--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -445,6 +445,9 @@ export abstract class SfCommand<T> extends Command {
       code: codeFromError,
       // @ts-expect-error because context is not on Error
       context: (error.context as string) ?? null,
+      commandName: (error as SfCommand.Error).commandName ?? null,
+      // @ts-expect-error because result is not on Error
+      result: (error.result as unknown) ?? null,
     });
 
     // Create printable error object
@@ -557,6 +560,7 @@ export namespace SfCommand {
     exitCode?: number;
     data?: unknown;
     context?: string;
+    commandName?: string;
   }
 }
 

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -438,16 +438,12 @@ export abstract class SfCommand<T> extends Command {
     process.exitCode ??= codeFromError;
 
     const sfErrorProperties = removeEmpty({
-      // @ts-expect-error because data is not on Error
-      data: (error.data as unknown) ?? null,
-      // @ts-expect-error because actions is not on Error
-      actions: (error.actions as string[]) ?? null,
       code: codeFromError,
-      // @ts-expect-error because context is not on Error
-      context: (error.context as string) ?? null,
-      commandName: (error as SfCommand.Error).commandName ?? null,
-      // @ts-expect-error because result is not on Error
-      result: (error.result as unknown) ?? null,
+      actions: 'actions' in error ? error.actions : null,
+      context: 'context' in error ? error.context : null,
+      commandName: 'commandName' in error ? error.commandName : null,
+      data: 'data' in error ? error.data : null,
+      result: 'result' in error ? error.result : null,
     });
 
     // Create printable error object

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -440,8 +440,8 @@ export abstract class SfCommand<T> extends Command {
     const sfErrorProperties = removeEmpty({
       code: codeFromError,
       actions: 'actions' in error ? error.actions : null,
-      context: 'context' in error ? error.context : null,
-      commandName: 'commandName' in error ? error.commandName : null,
+      context: 'context' in error ? error.context : this.statics.name,
+      commandName: 'commandName' in error ? error.commandName : this.statics.name,
       data: 'data' in error ? error.data : null,
       result: 'result' in error ? error.result : null,
     });


### PR DESCRIPTION
Adds more properties to the error caught in SfCommand to support push --json errors.

@W-13100374@