### PR TITLE
fix: check oclif exit code first

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     with:
       packageName: '@salesforce/sf-plugins-core'
       externalProjectGitUrl: 'https://github.com/salesforcecli/plugin-deploy-retrieve'
-      preBuildCommands: 'shx rm -rf node_modules/@oclif/core; shx rm -rf node_modules/@salesforce/kit; shx rm -rf node_modules/@salesforce/core; shx rm -rf node_modules/@salesforce/ts-types'
+      preBuildCommands: 'shx rm -rf node_modules/@oclif/core; shx rm -rf node_modules/@salesforce/kit; shx rm -rf node_modules/@salesforce/core; shx rm -rf node_modules/@salesforce/ts-types; shx rm -rf node_modules/@salesforce/cli-plugins-testkit'
       command: ${{ matrix.command }}
       os: ${{ matrix.os }}
     secrets: inherit

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -429,7 +429,7 @@ export abstract class SfCommand<T> extends Command {
 
     // @ts-expect-error because exitCode is not on Error
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const codeFromError = (error.exitCode as number | undefined) ?? (error.oclif?.exit as number | undefined) ?? 1;
+    const codeFromError = (error.oclif?.exit as number | undefined) ?? (error.exitCode as number | undefined) ?? 1;
     process.exitCode ??= codeFromError;
 
     const sfErrorProperties = removeEmpty({


### PR DESCRIPTION
`SfError` adds `exitCode: 1` by default which means that our configured exit codes for oclif-level errors are being ignored. This PR switches the logic to check for `oclif.exit` before checking `exitCode`

[skip-validate-pr]