### PR TITLE
feat: export oclif's `option` flag

### DIFF
--- a/src/exported.ts
+++ b/src/exported.ts
@@ -30,6 +30,7 @@ export const Flags = {
   string: OclifFlags.string,
   url: OclifFlags.url,
   custom: OclifFlags.custom,
+  option: OclifFlags.option,
   duration: durationFlag,
   salesforceId: salesforceIdFlag,
   orgApiVersion: orgApiVersionFlag,


### PR DESCRIPTION
Adds oclif's `Flags.option` to sf-plugins-core flags.