### PR TITLE
fix: bump core to 6.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@inquirer/confirm": "^2.0.17",
     "@inquirer/password": "^1.1.16",
     "@oclif/core": "^3.19.6",
-    "@salesforce/core": "^6.5.6",
+    "@salesforce/core": "^6.6.0",
     "@salesforce/kit": "^3.0.15",
     "@salesforce/ts-types": "^2.0.9",
     "chalk": "^5.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,10 +617,34 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@salesforce/core@^6.5.1", "@salesforce/core@^6.5.6":
+"@salesforce/core@^6.5.1":
   version "6.5.6"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.5.6.tgz#d32f6c89902298c7bbff010821a8856ecb2bb2dc"
   integrity sha512-ycUvOQi5MYVbDcdYgQ+99ym0FxrSo3c//2IHNkEYX0XdaTapN/63WKZ8hQufKYyucGnGZsPEhVWvrOR6oUV8qQ==
+  dependencies:
+    "@salesforce/kit" "^3.0.15"
+    "@salesforce/schemas" "^1.6.1"
+    "@salesforce/ts-types" "^2.0.9"
+    "@types/semver" "^7.5.8"
+    ajv "^8.12.0"
+    change-case "^4.1.2"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsforce "^2.0.0-beta.29"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^8.19.0"
+    pino-abstract-transport "^1.1.0"
+    pino-pretty "^10.3.1"
+    proper-lockfile "^4.1.2"
+    semver "^7.6.0"
+    ts-retry-promise "^0.7.1"
+
+"@salesforce/core@^6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.6.0.tgz#1f59220640f4c6b69c0a9c65c286c22bd5d3281b"
+  integrity sha512-bewX4fU3vTyCmcrRC74FstDaJI22itWaglFPlOiU4q8Z5sbu6SSHu5BmJ5ok/4BsEhQ8hzh1xvrmmLqwXcTRfg==
   dependencies:
     "@salesforce/kit" "^3.0.15"
     "@salesforce/schemas" "^1.6.1"


### PR DESCRIPTION
bump `@salesforce/core` to v6.6.0

[skip-validate-pr]