### PR TITLE
feat!: add flags-dir base flag

### DIFF
--- a/messages/messages.md
+++ b/messages/messages.md
@@ -112,3 +112,7 @@ Found duplicate argument %s.
 # warning.arrayInputFormat
 
 The input format for array arguments has changed. Use this format: --array-flag value1 --array-flag value2 --array-flag value3
+
+# flags.flags-dir.summary
+
+Import flag values from a directory.

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import os from 'node:os';
-import { Command, Config, HelpSection } from '@oclif/core';
+import { Command, Config, HelpSection, Flags } from '@oclif/core';
 import {
   envVars,
   Messages,
@@ -121,6 +121,13 @@ export abstract class SfCommand<T> extends Command {
    * ```
    */
   public static errorCodes?: HelpSection;
+
+  public static baseFlags = {
+    'flags-dir': Flags.directory({
+      summary: messages.getMessage('flags.flags-dir.summary'),
+      helpGroup: 'GLOBAL',
+    }),
+  };
 
   /**
    * Set to true if the command must be executed inside a Salesforce project directory.


### PR DESCRIPTION
Add `--flags-dir` as a base flag for all commands that extend `SfCommand`

Breaking change because abstract classes that extend `SfCommand` **and** define `baseFlags` will fail typescript compilation. Solution is to spread `SfCommand.baseFlags` onto your abstract class' `baseFlags`. Example

```typescript
// src/base-command.ts
import {SfCommand, Flags} from '@salesforce/sf-plugins-core'

export abstract class BaseCommand extends SfCommand {
  public static baseFlags = {
    ...SfCommand.baseFlags,
    'global-flag': Flags.boolean()
  } 
}


// src/commands/my-command.ts
import {BaseCommand} from '../base-command.ts'
import {Flags} from '@salesforce/sf-plugins-core'

export default class MyCommand extends BaseCommand {
  public static flags = {
    'my-flag': Flags.boolean()
  }

  public async run(): Promise<void> {
    // do stuff
  }
}
```

Needs https://github.com/salesforcecli/plugin-data/pull/864 for external nuts to pass

@W-15213828@