### PR TITLE
fix: pass command id to sfCommandError event

### DIFF
--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -422,7 +422,7 @@ export abstract class SfCommand<T> extends Command {
 
     // Emit an event for plugin-telemetry prerun hook to pick up.
     // @ts-expect-error because TS is strict about the events that can be emitted on process.
-    process.emit('sfCommandError', err);
+    process.emit('sfCommandError', err, this.id);
 
     throw err;
   }


### PR DESCRIPTION
Pass the command id to the `sfCommandError` event so that plugin-telemetry doesn't record duplicate errors when two commands fail in the same process (e.g. a `plugins install` of a JIT plugin before running the provided command)

@W-15428397@