### PR TITLE
feat: add a default summary for optional orgs

### DIFF
--- a/messages/messages.md
+++ b/messages/messages.md
@@ -42,9 +42,17 @@ The specified org %s is not a Dev Hub.
 
 Username or alias of the target org. Not required if the `target-org` configuration variable is already set.
 
+# flags.optionalTargetOrg.summary
+
+Username or alias of the target org.
+
 # flags.targetDevHubOrg.summary
 
 Username or alias of the Dev Hub org. Not required if the `target-dev-hub` configuration variable is already set.
+
+# flags.optionalTargetDevHubOrg.summary
+
+Username or alias of the Dev Hub org.
 
 # flags.apiVersion.description
 

--- a/src/flags/orgFlags.ts
+++ b/src/flags/orgFlags.ts
@@ -102,6 +102,7 @@ export const optionalOrgFlag = Flags.custom({
   char: 'o',
   noCacheDefault: true,
   parse: async (input: string | undefined) => maybeGetOrg(input),
+  summary: messages.getMessage('flags.optionalTargetOrg.summary'),
   default: async () => maybeGetOrg(),
   defaultHelp: async (context) => {
     if (context.options instanceof Org) {
@@ -211,7 +212,7 @@ export const requiredHubFlag = Flags.custom({
  */
 export const optionalHubFlag = Flags.custom({
   char: 'v',
-  summary: messages.getMessage('flags.targetDevHubOrg.summary'),
+  summary: messages.getMessage('flags.optionalTargetDevHubOrg.summary'),
   noCacheDefault: true,
   parse: async (input: string | undefined) => maybeGetHub(input),
   default: async () => maybeGetHub(),


### PR DESCRIPTION
[@W-15895601@](https://gus.lightning.force.com/a07EE00001slw9jYAA)

caught by QA on https://github.com/salesforcecli/plugin-deploy-retrieve/pull/1028