### PR TITLE
Wr/smarter suggestion

### DIFF
--- a/src/SfCommandError.ts
+++ b/src/SfCommandError.ts
@@ -113,7 +113,7 @@ export class SfCommandError extends SfError {
     const aggregator: Array<{ flag: string; args: string[] }> = [];
     output.forEach((k, i) => {
       let argCounter = i + 1;
-      if (k.type === 'flag' && output[argCounter].type === 'arg') {
+      if (k.type === 'flag' && output[argCounter]?.type === 'arg') {
         const args: string[] = [];
         while (output[argCounter]?.type === 'arg') {
           args.push(output[argCounter].input);

--- a/src/SfCommandError.ts
+++ b/src/SfCommandError.ts
@@ -110,25 +110,20 @@ export class SfCommandError extends SfError {
      --second "my second"
     */
 
-    // find the flag before the 'args' block that's valid, to append the args with its value as a suggestion
-    // const target = output.find((flag, index) => flag.type === 'flag' && output[index + 1]?.type === 'arg');
-
-    const catcher: Array<{ flag: string; args: string[] }> = [];
+    const aggregator: Array<{ flag: string; args: string[] }> = [];
     output.forEach((k, i) => {
       let argCounter = i + 1;
       if (k.type === 'flag' && output[argCounter].type === 'arg') {
         const args: string[] = [];
-        // add the flag name, and first correctly parsed value to the suggestion
-
         while (output[argCounter]?.type === 'arg') {
           args.push(output[argCounter].input);
           argCounter++;
         }
-        catcher.push({ flag: k.flag, args: [k.input, ...args] });
+        aggregator.push({ flag: k.flag, args: [k.input, ...args] });
       }
     });
 
     this.actions ??= [];
-    this.actions.push(...catcher.map((cause) => `--${cause.flag} "${cause.args.join(' ')}"`));
+    this.actions.push(...aggregator.map((cause) => `--${cause.flag} "${cause.args.join(' ')}"`));
   }
 }

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -382,22 +382,7 @@ export abstract class SfCommand<T> extends Command {
       sfCommandError.exitCode === 2 &&
       error.message.includes('Unexpected argument')
     ) {
-      const output =
-        // @ts-expect-error error's causes aren't typed, this is what's returned from flag parsing errors
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        (sfCommandError.cause?.parse?.output?.raw as Array<{ flag: string; input: string; type: 'flag' | 'arg' }>) ??
-        [];
-
-      // find the extra arguments causing issues
-      const extras = output
-        .filter((f) => f.type === 'arg')
-        .flatMap((f) => f.input)
-        .join(' ');
-      // find the flag before the 'args' block that's valid, to append the args with its value as a suggestion
-      const target = output.find((flag, index) => flag.type === 'flag' && output[index + 1]?.type === 'arg');
-
-      sfCommandError.actions ??= [];
-      sfCommandError.actions.push(`--${target?.flag} "${target?.input} ${extras}"`);
+      sfCommandError.appendErrorSuggestions();
     }
 
     if (this.jsonEnabled()) {

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -382,9 +382,9 @@ export abstract class SfCommand<T> extends Command {
       sfCommandError.exitCode === 2 &&
       error.message.includes('Unexpected argument')
     ) {
-      // @ts-expect-error error's causes aren't typed, this is what's returned from flag parsing errors
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const output =
+        // @ts-expect-error error's causes aren't typed, this is what's returned from flag parsing errors
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         (sfCommandError.cause?.parse?.output?.raw as Array<{ flag: string; input: string; type: 'flag' | 'arg' }>) ??
         [];
 

--- a/test/unit/sfCommand.test.ts
+++ b/test/unit/sfCommand.test.ts
@@ -395,7 +395,7 @@ describe('error standardization', () => {
   it('should log correct suggestion when user doesnt wrap with quotes', async () => {
     const logToStderrStub = $$.SANDBOX.stub(SfCommand.prototype, 'logToStderr');
     try {
-      await SuggestionCommand.run(['--first', 'my', 'alias', 'with', 'spaces', '--second', 'my second value']);
+      await SuggestionCommand.run(['--first', 'my', 'alias', 'with', 'spaces', '--second', 'my second', 'value']);
       expect(false, 'error should have been thrown').to.be.true;
     } catch (e: unknown) {
       expect(e).to.be.instanceOf(SfCommandError);
@@ -407,7 +407,7 @@ describe('error standardization', () => {
 
       // Ensure the error has expected properties
       expect(err).to.have.property('actions');
-      expect(err.actions).to.deep.equal(['--first "my alias with spaces"']);
+      expect(err.actions).to.deep.equal(['--first "my alias with spaces"', '--second "my second value"']);
       expect(err).to.have.property('exitCode', 2);
       expect(err).to.have.property('context', 'SuggestionCommand');
       expect(err).to.have.property('data', undefined);


### PR DESCRIPTION
@W-15921199@

parses error message to find when the user didn't encapsulate strings with spaces correctly
BEFORE:
```bash
 ➜  sf org logout --target-org test org my demo org too --all
Error (2): Unexpected arguments: org, org, my, demo, too
See more help with --help
```

AFTER
```bash
 ➜  ../../oss/plugin-auth/bin/run.js org logout --all --target-org test org my demo org too                   
Error (2): Unexpected arguments: org, org, my, demo, too
See more help with --help

Try this:

--target-org "test org my demo org too"
```