### PR TITLE
feat: flush intra-command warnings at the end

### DIFF
--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -399,12 +399,14 @@ export abstract class SfCommand<T> extends Command {
     throw sfCommandError;
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
-  protected async finally(): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-explicit-any
+  protected async finally(_: Error | undefined): Promise<any> {
     // flush warnings
     this.warningsToFlush.forEach((warning) => {
       this.warn(warning);
     });
+
+    return super.finally(_);
   }
 
   public abstract run(): Promise<T>;


### PR DESCRIPTION
Flush warnings sent via `Lifecycle.emitWarning` at the end of the command execution.

**Note** plugin-settings NUTs are failing because warnings are not ordered as they were before. Those nuts shouldn't depend on order

@W-16438012@