### PR TITLE
fix: bump oclif/table

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     with:
       packageName: '@salesforce/sf-plugins-core'
       externalProjectGitUrl: 'https://github.com/salesforcecli/plugin-deploy-retrieve'
-      preBuildCommands: 'shx rm -rf node_modules/@oclif/core node_modules/@salesforce/kit node_modules/@salesforce/core node_modules/@salesforce/ts-types node_modules/@salesforce/cli-plugins-testkit'
+      preBuildCommands: 'shx rm -rf node_modules/@oclif/core node_modules/@oclif/table node_modules/@salesforce/kit node_modules/@salesforce/core node_modules/@salesforce/ts-types node_modules/@salesforce/cli-plugins-testkit'
       command: ${{ matrix.command }}
       os: ${{ matrix.os }}
     secrets: inherit
@@ -67,7 +67,7 @@ jobs:
     with:
       packageName: '@salesforce/sf-plugins-core'
       externalProjectGitUrl: 'https://github.com/salesforcecli/${{matrix.repo}}'
-      preBuildCommands: 'shx rm -rf node_modules/@oclif/core node_modules/@salesforce/kit node_modules/@salesforce/core node_modules/@salesforce/ts-types'
+      preBuildCommands: 'shx rm -rf node_modules/@oclif/core node_modules/@oclif/table node_modules/@salesforce/kit node_modules/@salesforce/core node_modules/@salesforce/ts-types'
       command: yarn test:nuts
       os: ${{ matrix.os }}
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@inquirer/confirm": "^3.1.22",
     "@inquirer/password": "^2.2.0",
     "@oclif/core": "^4.0.27",
-    "@oclif/table": "^0.3.0",
+    "@oclif/table": "^0.3.2",
     "@salesforce/core": "^8.5.1",
     "@salesforce/kit": "^3.2.3",
     "@salesforce/ts-types": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -52,9 +52,6 @@
     "@salesforce/ts-types": "^2.0.12",
     "ansis": "^3.3.2",
     "cli-progress": "^3.12.0",
-    "natural-orderby": "^3.0.2",
-    "slice-ansi": "^7.1.0",
-    "string-width": "^7.2.0",
     "terminal-link": "^3.0.0"
   },
   "devDependencies": {

--- a/test/unit/ux/ux.test.ts
+++ b/test/unit/ux/ux.test.ts
@@ -32,11 +32,9 @@ describe('Ux', () => {
         ux.table({ data: [{ key: 'foo', value: 'bar' }], title: 'Title' });
       });
       expect(stdout.replaceAll(' \n', '\n').trimEnd()).to.equal(`Title
-┌─────┬───────┐
-│ Key │ Value │
-├─────┼───────┤
-│ foo │ bar   │
-└─────┴───────┘`);
+ Key  Value
+------------
+ foo  bar`);
     });
 
     it('should not log anything if output is not enabled', async () => {
@@ -56,11 +54,9 @@ describe('Ux', () => {
         ux.table(opts);
       });
       expect(stdout.replaceAll(' \n', '\n').trimEnd()).to.equal(`Title
-┌─────┬───────┐
-│ Key │ Value │
-├─────┼───────┤
-│ foo │ bar   │
-└─────┴───────┘`);
+ Key  Value
+------------
+ foo  bar`);
     });
 
     it('should not log anything if output is not enabled', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -582,10 +582,10 @@
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/table@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@oclif/table/-/table-0.3.0.tgz#b87ba5d20e7e84a1d4744e68c64093dbc8bd8de9"
-  integrity sha512-HzUUyNcoEzfyvzzXL1evLZmiMBZ2SnH41lNHpoKJZJR4uCdiMkOzlkLf9M326qLmRJTDpKnUHgIZD778T647gg==
+"@oclif/table@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@oclif/table/-/table-0.3.2.tgz#192a310488af67a7341ba203a0e3a0d67f1d8693"
+  integrity sha512-H8B41sRuXByT4E3ROSICbiQBbZDD3Kw30vYkJlPvKbE5QGEd11hPo+P9ahdGLA3AY0SkTflfTily8fFhHT0WDA==
   dependencies:
     "@oclif/core" "^4"
     "@types/react" "^18.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4980,7 +4980,7 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-string-width@^7.0.0, string-width@^7.2.0:
+string-width@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
   integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==


### PR DESCRIPTION
- Bump @oclif/table
- Remove unneeded deps (used for the old table)

(plugin-signups tests are expected to fail until that plugin is migrated to the new major)

[skip-validate-pr]