### PR TITLE
fix: use SF env var in loglevel msg

### DIFF
--- a/messages/messages.md
+++ b/messages/messages.md
@@ -97,7 +97,7 @@ Warning:
 # warning.loglevel
 
 The loglevel flag is no longer in use on this command. You may use it without error, but it will be ignored.
-Set the log level using the `SFDX_LOG_LEVEL` environment variable.
+Set the log level using the `SF_LOG_LEVEL` environment variable.
 
 # actions.tryThis
 


### PR DESCRIPTION
updates `--loglevel` msg to mention `SF` style env var instead of the `SFDX` ones, no functional change since sfdx-core supports both

```
➜  jsforce git:(main) ✗ sf org display --loglevel DEBUG
Warning: The loglevel flag is no longer in use on this command. You may use it without error, but it will be ignored.
Set the log level using the `SFDX_LOG_LEVEL` environment variable.
```

[skip-validate-pr]