### PR TITLE
W-17908565 Add a preview state for commands

### DIFF
--- a/messages/messages.md
+++ b/messages/messages.md
@@ -107,6 +107,10 @@ Try this:
 
 This command is currently in beta. Any aspect of this command can change without advanced notice. Don't use beta commands in your scripts.
 
+# warning.CommandInPreview
+
+This command is currently in preview. Preview commands will likely change before shipping, use at your own risk. Don't use preview commands in your scripts.
+
 # error.InvalidArgumentFormat
 
 Error in the following argument

--- a/src/sfCommand.ts
+++ b/src/sfCommand.ts
@@ -327,9 +327,17 @@ export abstract class SfCommand<T> extends Command {
       ...(this.statics.requiresProject ? [assignProject()] : []),
     ]);
 
-    if (this.statics.state === 'beta') {
-      this.warn(messages.getMessage('warning.CommandInBeta'));
+    switch (this.statics.state) {
+      case 'beta':
+        this.warn(messages.getMessage('warning.CommandInBeta'));
+        break;
+      case 'preview':
+        this.warn(messages.getMessage('warning.CommandInPreview'));
+        break;
+      default:
+        break;
     }
+
     // eslint-disable-next-line @typescript-eslint/require-await
     this.lifecycle.onWarning(async (warning: string) => {
       this.warningsToFlush.push(warning);


### PR DESCRIPTION
Adds a new `preview` state for commands. 

<img width="2001" alt="Screenshot 2025-02-25 at 1 54 39 PM" src="https://github.com/user-attachments/assets/b5cdc02e-128a-4c8d-ab67-49036a259624" />

Testing:
- pull branch
- yarn build
- yarn link
- cd to another plugin
- run `yarn link "@salesforce/sf-plugins-core"`
- set `public static state = 'preview';` on one command
- Run that command. You'll see the new message

