### PR TITLE
fix: bump @salesforce/core to v9.1.4 @W-23807280@

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@inquirer/password": "^5.1.1",
     "@oclif/core": "^4.11.4",
     "@oclif/table": "^0.5.9",
-    "@salesforce/core": "^9.1.3",
+    "@salesforce/core": "^9.1.4",
     "@salesforce/kit": "^4.0.0",
     "@salesforce/ts-types": "^3.0.0",
     "ansis": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -581,10 +581,25 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jsforce/jsforce-node@^3.10.13", "@jsforce/jsforce-node@^3.10.17":
+"@jsforce/jsforce-node@^3.10.13":
   version "3.10.17"
   resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.17.tgz#c8f0a9d3b88925d45b297f2a9dac8af2a17c47ee"
   integrity sha512-gYWiK0Y68dMUTdlPjkF+Bw3r7pmfTbqzs7/6ZChg2Md14NyzXk/usp+y8hHj6vc1SF3s7e6j5OUzUasYF5RJWQ==
+  dependencies:
+    "@sindresorhus/is" "^4"
+    base64url "^3.0.1"
+    csv-parse "^5.5.2"
+    csv-stringify "^6.6.0"
+    faye "^1.4.0"
+    form-data "^4.0.4"
+    multistream "^3.1.0"
+    undici "^8.5.0"
+    xml2js "^0.6.2"
+
+"@jsforce/jsforce-node@^3.10.22":
+  version "3.10.22"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.22.tgz#b15d0bfa8280dff3d2b6d5a833a6febb6bef138c"
+  integrity sha512-4TLjnvTlBW59NmNSsRRV5dDEepQGfBKVD0WWQlJUJwkU0d5FFxo8GbfNmCOXkjjYAe1wv7SuvMzJKcLZHU6qyw==
   dependencies:
     "@sindresorhus/is" "^4"
     base64url "^3.0.1"
@@ -752,12 +767,12 @@
     ts-retry-promise "^0.8.1"
     zod "^4.1.12"
 
-"@salesforce/core@^9.1.3":
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-9.1.3.tgz#253ed24c7ccff7fa1d9b601dcc325153f532e090"
-  integrity sha512-4Eeu42uGLk2WZHgAeAIUgmo359SOcXju0J+yJWLDUjEXAXM41TdyNsUptAjw0D0R+0duw9+i0g45/8V0kNsxUQ==
+"@salesforce/core@^9.1.4":
+  version "9.1.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-9.1.4.tgz#264a618f962b7306794d5a7a42698bdb7dec6d04"
+  integrity sha512-S4VZ0xstYOAs5dwt7EDGkuFZA8rddy0wmuPTGjsIhgAPzuq3I5lKyBNwqXMMxdhBcWi+P4cXccHLpOYivgdrXQ==
   dependencies:
-    "@jsforce/jsforce-node" "^3.10.17"
+    "@jsforce/jsforce-node" "^3.10.22"
     "@salesforce/kit" "^4.0.0"
     "@salesforce/ts-types" "^3.0.0"
     ajv "^8.18.0"


### PR DESCRIPTION
Bumps @salesforce/core to v9.1.4 in order to pick up bug fixes from @jsforce/jsforce-node v3.10.22.

Addresses [@W-23807280@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002hCJ0nYAG/view)